### PR TITLE
support PyInstaller as bundler

### DIFF
--- a/wflow-py/Scripts/wtools_py/create_grid.py
+++ b/wflow-py/Scripts/wtools_py/create_grid.py
@@ -14,12 +14,17 @@ $Keywords: $
 """
 
 # import sys packages
-from hydrotools import gis
 import sys
 import os
 import shutil
+
 # import admin packages
 from optparse import OptionParser
+
+# if frozen to exe, import wflow is needed before hydrotools to run __init__
+# and set the PROJ_DIR environment variable to the right path
+import wflow
+from hydrotools import gis
 
 # import general packages
 import numpy as np

--- a/wflow-py/Scripts/wtools_py/static_maps.py
+++ b/wflow-py/Scripts/wtools_py/static_maps.py
@@ -28,6 +28,9 @@ import numpy as np
 from osgeo import osr, gdal, ogr, gdalconst
 
 # import specific packages
+# if frozen to exe, import wflow is needed before hydrotools to run __init__
+# and set the PROJ_DIR environment variable to the right path
+import wflow
 from hydrotools import gis
 import pcraster as pcr
 import wflow.wflowtools_lib as wt

--- a/wflow-py/_version.py
+++ b/wflow-py/_version.py
@@ -1,4 +1,5 @@
-# This file is made by mkversion.py, do not edit!VERSION="1.0.master.1"
-MVERSION="1.0.master"
-NVERSION="1.0.1"
-BUILD="2017-06-20 11:12:59.689000"
+# This file is made by mkversion.py, do not edit!
+VERSION='1.0.master.1'
+MVERSION='1.0.master'
+NVERSION='1.0.1'
+BUILD='2017-06-20 11:12:59.689000'

--- a/wflow-py/mkversion.py
+++ b/wflow-py/mkversion.py
@@ -1,19 +1,19 @@
 import os
 import datetime
-
 import subprocess
 
 branch = None
 
 try:
-    branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).strip()
+    branch = subprocess.check_output(
+        'git rev-parse --abbrev-ref HEAD', shell=True).strip()
 except:
     branch = None
 
 if branch == None:
     branch = 'master'
 
-vers='1'
+vers = '1'
 nrversion = '1.0'
 
 ###################################
@@ -21,33 +21,39 @@ manualversion = nrversion + "." + branch + "." + vers
 manualmainversion = nrversion + "." + branch
 version = nrversion = '1.0' + "." + vers
 ###################################
-a = open("_version.py","w")
+a = open("_version.py", "w")
 
-build=datetime.datetime.now()
+build = datetime.datetime.now()
 
-a.write("# This file is made by mkversion.py, do not edit!")
-a.write("VERSION=\"" + manualversion +  "\"\n")
-a.write("MVERSION=\"" + manualmainversion +"\"\n")
-a.write("NVERSION=\"" + version +"\"\n")
-a.write("BUILD=\"" + str(build) +"\"\n")
+a.write("# This file is made by mkversion.py, do not edit!\n")
+a.write("VERSION='" + manualversion + "'\n")
+a.write("MVERSION='" + manualmainversion + "'\n")
+a.write("NVERSION='" + version + "'\n")
+a.write("BUILD='" + str(build) + "'\n")
 a.close()
 
-a = open("wflow/__init__.py","w")
-a.write("__all__ = [\"wflow_funcs\",\"wflow_adapt\",\"wflow_lib\",\"pcrut\",\"wf_DynamicFramework\",\"stats\"]\n")
-a.write("__version__=\"" + manualmainversion + "\"\n")
-a.write("__release__=\"" + manualversion + "\"\n")
-a.write("__versionnr__=\"" + version + "\"\n")
-a.write("__build__=\"" + str(build) + "\"\n")
-a.write("import osgeo.gdal as gdal\n\n")
+a = open("wflow/__init__.py", "w")
+a.write(
+    "__all__ = ['wflow_funcs','wflow_adapt','wflow_lib','pcrut','wf_DynamicFramework','stats']\n")
+a.write("__version__='" + manualmainversion + "'\n")
+a.write("__release__='" + manualversion + "'\n")
+a.write("__versionnr__='" + version + "'\n")
+a.write("__build__='" + str(build) + "'\n\n")
 a.write("import os, sys\n")
-a.write("if hasattr(sys, \"frozen\"):\n")
-a.write("    _ROOT = os.path.abspath(os.path.dirname(__file__)).split(\"library.zip\")[0]\n")
-a.write("    os.environ['GDAL_DATA'] = os.path.join(_ROOT,'gdal-data')\n")
-a.write("else:\n")
-a.write("    _ROOT = os.path.abspath(os.path.dirname(__file__))\n\n")
-
-a.write("def get_data(path):\n")
-a.write("    return os.path.join(_ROOT, 'data', path)\n")
+a.write("import osgeo.gdal as gdal\n\n")
+a.write("if getattr(sys, 'frozen', False):\n")
+a.write("    # running in a bundle\n")
+a.write("    # sys._MEIPASS is set by PyInstaller\n")
+a.write("    basedir = getattr(sys, '_MEIPASS', None)\n")
+a.write("    # support also other bundlers\n")
+a.write("    if not basedir:\n")
+a.write("        basedir = os.path.dirname(sys.executable)\n\n")
+a.write("    # use the included gdal-data\n")
+a.write("    gdal_data_path = os.path.join(basedir, 'gdal-data')\n")
+a.write("    gdal.SetConfigOption('GDAL_DATA', gdal_data_path)\n\n")
+a.write("    # set environment variable instead of pyproj_datadir such\n")
+a.write("    # that child processes will inherit it\n")
+a.write("    os.environ['PROJ_DIR'] = os.path.join(basedir, 'proj-data')\n")
 
 
 print "============================================================================="

--- a/wflow-py/pyinstall.cmd
+++ b/wflow-py/pyinstall.cmd
@@ -1,1 +1,1 @@
-pyi-build.exe wflow_all.spec
+pyinstaller --log-level WARN --noconfirm wflow_all.spec

--- a/wflow-py/wflow/__init__.py
+++ b/wflow-py/wflow/__init__.py
@@ -1,16 +1,24 @@
-__all__ = ["wflow_funcs","wflow_adapt","wflow_lib","pcrut","wf_DynamicFramework","stats"]
-__version__="1.0.master"
-__release__="1.0.master.1"
-__versionnr__="1.0.1"
-__build__="2017-06-20 11:12:59.689000"
-import osgeo.gdal as gdal
+__all__ = ['wflow_funcs','wflow_adapt','wflow_lib','pcrut','wf_DynamicFramework','stats']
+__version__='1.0.master'
+__release__='1.0.master.1'
+__versionnr__='1.0.1'
+__build__='2017-06-20 11:12:59.689000'
 
 import os, sys
-if hasattr(sys, "frozen"):
-    _ROOT = os.path.abspath(os.path.dirname(__file__)).split("library.zip")[0]
-    os.environ['GDAL_DATA'] = os.path.join(_ROOT,'gdal-data')
-else:
-    _ROOT = os.path.abspath(os.path.dirname(__file__))
+import osgeo.gdal as gdal
 
-def get_data(path):
-    return os.path.join(_ROOT, 'data', path)
+if getattr(sys, 'frozen', False):
+    # running in a bundle
+    # sys._MEIPASS is set by PyInstaller
+    basedir = getattr(sys, '_MEIPASS', None)
+    # support also other bundlers
+    if not basedir:
+        basedir = os.path.dirname(sys.executable)
+
+    # use the included gdal-data
+    gdal_data_path = os.path.join(basedir, 'gdal-data')
+    gdal.SetConfigOption('GDAL_DATA', gdal_data_path)
+
+    # set environment variable instead of pyproj_datadir such
+    # that child processes will inherit it
+    os.environ['PROJ_DIR'] = os.path.join(basedir, 'proj-data')


### PR DESCRIPTION
Tested with PyInstaller 3.2.1, resulting exes can run `wflow_rhine_sbm_nc` example without errors. Also all executables can start without crashing (unless they do because of missing command line arguments).

If UPX is available, compression will be applied. Even with compression the size of the final dist folder is currently around 280 MB. This can possibly be reduced by looking at what [excludes](http://pyinstaller.readthedocs.io/en/stable/spec-files.html) are possible to add.

__TODO__
- [ ] check if bundling with cx_Freeze still works
- [ ] try on clean machine with none of the dependencies installed
