### PR TITLE
use explicit imports

### DIFF
--- a/tests/test_FrameWork.py
+++ b/tests/test_FrameWork.py
@@ -1,8 +1,10 @@
 __author__ = "schelle"
 
-import unittest
-import wflow.wflow_sceleton as wf
 import os
+import unittest
+
+import numpy as np
+import wflow.wflow_sceleton as wf
 
 """
 Run sceleton for 10 steps and checks if the outcome is approx that of the reference run
@@ -38,9 +40,9 @@ class MyTest(unittest.TestCase):
         dynModelFw._runSuspend()  # saves the state variables
         dynModelFw._wf_shutdown()
 
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "tes.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "tes.csv"), delimiter=",")
         self.assertAlmostEqual(14.885358393192291, my_data[:, 2].sum())
-        my_data_mean = wf.genfromtxt(
+        my_data_mean = np.genfromtxt(
             os.path.join(caseName, runId, "tes_mean_5.csv"), delimiter=","
         )
         self.assertAlmostEqual(20.727288454771042, my_data_mean[:, 2].sum())

--- a/tests/test_wflow_hbv.py
+++ b/tests/test_wflow_hbv.py
@@ -1,8 +1,11 @@
 __author__ = "schelle"
 
+import datetime
+import os
 import unittest
+
+import numpy as np
 import wflow.wflow_hbv as wf
-import os, datetime
 
 """
 
@@ -54,14 +57,14 @@ class MyTest(unittest.TestCase):
 
         # nore read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "watbal.csv"), delimiter=","
         )
 
         print("Checking  water budget ....")
         self.assertAlmostEqual(0.0011471913849163684, my_data[:, 2].sum(), places=4)
 
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "run.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "run.csv"), delimiter=",")
         print("Checking  discharge ....")
         self.assertAlmostEqual(1086.9438420613608, my_data[:, 2].mean(), places=4)
 

--- a/tests/test_wflow_hbv2.py
+++ b/tests/test_wflow_hbv2.py
@@ -1,8 +1,11 @@
 __author__ = "schelle"
 
+import datetime
+import os
 import unittest
+
+import numpy as np
 import wflow.wflow_hbv as wf
-import os, datetime
 
 """
 
@@ -56,14 +59,14 @@ class MyTest(unittest.TestCase):
 
         # nore read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "watbal.csv"), delimiter=","
         )
 
         print("Checking  water budget ....")
         self.assertAlmostEqual(0.0011249125109316083, my_data[:, 2].sum(), places=4)
 
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "run.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "run.csv"), delimiter=",")
         print("Checking  discharge ....")
         self.assertAlmostEqual(1811.1795542081197, my_data[:, 2].mean(), places=4)
 

--- a/tests/test_wflow_sbm.py
+++ b/tests/test_wflow_sbm.py
@@ -1,8 +1,10 @@
 __author__ = "schelle"
 
-import unittest
-import wflow.wflow_sbm as wf
 import os
+import unittest
+
+import numpy as np
+import wflow.wflow_sbm as wf
 
 """
 Run wflow_sbm for 10 steps and checks if the outcome is approx that of the reference run
@@ -50,19 +52,19 @@ class MyTest(unittest.TestCase):
 
         # now read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsurf.csv"), delimiter=","
         )
 
         print("Checking surface water budget ....")
         self.assertAlmostEqual(-1.003901559215592e-06, my_data[:, 2].sum(), places=4)
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsoil.csv"), delimiter=","
         )
         print("Checking soil water budget ....")
         self.assertAlmostEqual(0.00055469494748194847, my_data[:, 2].sum(), places=4)
         print("Checking precip sum ....")
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
         self.assertAlmostEqual(sump, my_data[:, 2].sum())
 
 

--- a/tests/test_wflow_sbm_dynveg.py
+++ b/tests/test_wflow_sbm_dynveg.py
@@ -1,8 +1,10 @@
 __author__ = "schelle"
 
-import unittest
-import wflow.wflow_sbm as wf
 import os
+import unittest
+
+import numpy as np
+import wflow.wflow_sbm as wf
 
 """
 Run sceleton for 10 steps and checks if the outcome is approx that of the reference run
@@ -50,19 +52,19 @@ class MyTest(unittest.TestCase):
 
         # nore read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsurf.csv"), delimiter=",", skip_header=1
         )
 
         print("Checking surface water budget ....")
         self.assertAlmostEqual(-1.003901559215592e-06, my_data[:, 2].sum(), places=4)
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsoil.csv"), delimiter=","
         )
         print("Checking soil water budget ....")
         self.assertAlmostEqual(0.00040802343085033499, my_data[:, 2].sum(), places=4)
         print("Checking precip sum ....")
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
         self.assertAlmostEqual(sump, my_data[:, 2].sum())
 
 

--- a/tests/test_wflow_sbm_example.py
+++ b/tests/test_wflow_sbm_example.py
@@ -1,8 +1,10 @@
 __author__ = "schelle"
 
-import unittest
-import wflow.wflow_sbm as wf
 import os
+import unittest
+
+import numpy as np
+import wflow.wflow_sbm as wf
 
 """
 Run wflow_sbm for 10 steps and checks if the outcome is approx that of the reference run
@@ -42,7 +44,7 @@ class MyTest(unittest.TestCase):
 
         # now read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "specrun.csv"), delimiter=","
         )
 

--- a/tests/test_wflow_sbm_nc.py
+++ b/tests/test_wflow_sbm_nc.py
@@ -1,8 +1,10 @@
 __author__ = "schelle"
 
-import unittest
-import wflow.wflow_sbm as wf
 import os
+import unittest
+
+import numpy as np
+import wflow.wflow_sbm as wf
 
 """
 Run sceleton for 10 steps and checks if the outcome is approx that of the reference run
@@ -50,7 +52,7 @@ class MyTest(unittest.TestCase):
 
         # nore read the csv results acn check of they match the first run
         # Sum should be approx c 4.569673676
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsurf.csv"),
             delimiter=",",
             usecols=(0, 1, 2, 3, 4),
@@ -58,13 +60,13 @@ class MyTest(unittest.TestCase):
 
         print("Checking surface water budget ....")
         self.assertAlmostEqual(3.574188167654313e-09, my_data[:, 2].sum(), places=4)
-        my_data = wf.genfromtxt(
+        my_data = np.genfromtxt(
             os.path.join(caseName, runId, "wbsoil.csv"), delimiter=","
         )
         print("Checking soil water budget ....")
         self.assertAlmostEqual(0.0026834408363356488, my_data[:, 2].sum(), places=4)
         print("Checking precip sum ....")
-        my_data = wf.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
+        my_data = np.genfromtxt(os.path.join(caseName, runId, "P.csv"), delimiter=",")
         self.assertAlmostEqual(sump, my_data[:, 2].sum())
 
 

--- a/wflow/JarvisCoefficients.py
+++ b/wflow/JarvisCoefficients.py
@@ -16,6 +16,7 @@ use hourly evaporation as model input
 Calculations based on Zhou et al 2006 and Stewart 1998
 """
 
+import math
 
 try:
     from wflow.wf_DynamicFramework import *
@@ -29,7 +30,7 @@ def calcEp(self, k):
     """
     #    resistenceAeroD(self)
     #    potential_evaporation(self,k)
-    self.EpDay = ifthenelse(
+    self.EpDay = pcr.ifthenelse(
         self.Sw_t[k] > 0, self.EpDaySnow2, self.EpDay2
     )  # EpDaySnow added on 18-02-2016
     downscale_evaporation(self, k)
@@ -42,7 +43,7 @@ def calcEpSnow(self, k):
     """
     #    resistenceAeroD(self)
     #    potential_evaporation(self,k)
-    self.EpDaySnow = ifthenelse(
+    self.EpDaySnow = pcr.ifthenelse(
         self.Sw_t[k] > 0,
         self.EpDaySnow2 * self.lamda / self.lamdaS,
         self.EpDay2 * self.lamda / self.lamdaS,
@@ -58,7 +59,7 @@ def calcEpSnowHour(self, k):
     """
     #    resistenceAeroD(self)
     #    potential_evaporation(self,k)
-    self.EpHour = ifthenelse(
+    self.EpHour = pcr.ifthenelse(
         self.Sw_t[k] > 0,
         self.EpDaySnow2 * self.lamda / self.lamdaS,
         self.EpDay2 * self.lamda / self.lamdaS,
@@ -109,16 +110,16 @@ def JC_temperature(self, k):
         - Topt (optimum temperature for transpiration, based on elevation and latitude (Cui et al, 2012))
     """
     self.JC_ToptC = self.JC_Topt - 273.15  # changed on 9/4/2015, before Topt in K
-    JC_temp1 = ifthenelse(
+    JC_temp1 = pcr.ifthenelse(
         self.Tmean < 273.15,
         0,
-        ifthenelse(
-            pcrand(self.Tmean >= self.JC_Topt - 1, self.Tmean <= self.JC_Topt + 1),
+        pcr.ifthenelse(
+            pcr.pcrand(self.Tmean >= self.JC_Topt - 1, self.Tmean <= self.JC_Topt + 1),
             1,
             1 - self.JC_Topt ** -2 * (self.Tmean - self.JC_Topt) ** 2,
         ),
     )
-    self.JC_temp = ifthenelse(JC_temp1 < 0, 0, JC_temp1)
+    self.JC_temp = pcr.ifthenelse(JC_temp1 < 0, 0, JC_temp1)
     self.JC_temp_[k] = self.JC_temp
 
 
@@ -134,7 +135,7 @@ def JC_vapourDeficit(self, k):
 
     denom = 1 + (self.vpd / self.JC_D05[k]) ** self.JC_cd1[k]
     JC_vpd1 = (1 / denom) * (1 - self.JC_cd2[k]) + self.JC_cd2[k]
-    self.JC_vpd = ifthenelse(JC_vpd1 < 0, 0, JC_vpd1)
+    self.JC_vpd = pcr.ifthenelse(JC_vpd1 < 0, 0, JC_vpd1)
     self.JC_vpd_[k] = self.JC_vpd
 
 
@@ -161,7 +162,7 @@ def JC_solarRadiation(self, k):
     JC_rad1 = (
         rad_si_Wm2 * (1 + self.JC_cr[k] / 1000) * (1 / (self.JC_cr[k] + rad_si_Wm2))
     )
-    self.JC_rad = ifthenelse(JC_rad1 < 0, 0, JC_rad1)
+    self.JC_rad = pcr.ifthenelse(JC_rad1 < 0, 0, JC_rad1)
     self.JC_rad_[k] = self.JC_rad
 
 
@@ -175,10 +176,10 @@ def JC_soilMoisture(self, k):
         - SuWP (level of saturation in soil at wilting point)
     """
     SuN = self.Su[k] / self.sumax[k]
-    JC_sm1 = ifthenelse(
+    JC_sm1 = pcr.ifthenelse(
         SuN < self.SuWP[k],
         0,
-        ifthenelse(
+        pcr.ifthenelse(
             SuN > self.SuFC[k],
             1,
             (SuN - self.SuWP[k])
@@ -186,7 +187,7 @@ def JC_soilMoisture(self, k):
             / ((self.SuFC[k] - self.SuWP[k]) * (SuN - self.SuWP[k] + self.JC_cuz[k])),
         ),
     )
-    self.JC_sm = ifthenelse(JC_sm1 < 0, 0, JC_sm1)
+    self.JC_sm = pcr.ifthenelse(JC_sm1 < 0, 0, JC_sm1)
     self.JC_sm_[k] = self.JC_sm
 
 
@@ -214,8 +215,8 @@ def resistenceTotal(self, k):
         - gamma (psychrometric constant)
     """
     JC_all = self.JC_laiEff * self.JC_rad * self.JC_vpd * self.JC_temp * self.JC_sm
-    stomRes1 = ifthenelse(JC_all == 0, 50000, self.JC_rstmin[k] / JC_all)
-    stomRes2 = ifthenelse(stomRes1 > 50000, 50000, stomRes1)
+    stomRes1 = pcr.ifthenelse(JC_all == 0, 50000, self.JC_rstmin[k] / JC_all)
+    stomRes2 = pcr.ifthenelse(stomRes1 > 50000, 50000, stomRes1)
     self.stomRes = stomRes2 / (3600 * 24)
 
     self.k = 1 / (
@@ -235,8 +236,8 @@ def resistenceTotal_laiHRU(self, k):
         - gamma (psychrometric constant)
     """
     JC_all = self.JC_rad * self.JC_vpd * self.JC_temp * self.JC_sm
-    stomRes1 = ifthenelse(JC_all == 0, 50000, self.rst_lai[k] / JC_all)
-    stomRes2 = ifthenelse(stomRes1 > 50000, 50000, stomRes1)
+    stomRes1 = pcr.ifthenelse(JC_all == 0, 50000, self.rst_lai[k] / JC_all)
+    stomRes2 = pcr.ifthenelse(stomRes1 > 50000, 50000, stomRes1)
     self.stomRes = stomRes2 / (3600 * 24)
 
     self.k = 1 / (
@@ -276,22 +277,22 @@ def downscale_evaporation(self, k):
     - 
     """
 
-    # teller = numpy.nanmax(pcr2numpy(self.thestep,nan))
-    teller = pcr2numpy(self.thestep, nan)[0, 0]
-    x = teller - floor(teller / 24) * 24 * scalar(self.catchArea)
+    # teller = numpy.nanmax(pcr.pcr2numpy(self.thestep,np.nan))
+    teller = pcr.pcr2numpy(self.thestep, np.nan)[0, 0]
+    x = teller - math.floor(teller / 24) * 24 * pcr.scalar(self.catchArea)
     DL = self.DE - self.DS + 1
-    P = 2 * pi / (2 * DL)  # period
+    P = 2 * math.pi / (2 * DL)  # period
     SH = DL - 12  # horizontal shift of new signal
     aN = -1 * self.EpDay * P  # nominator of the amplitude
-    aDN = sin((P * (self.DE + SH)) * 180 / pi) - sin(
-        (P * (self.DS + SH)) * 180 / pi
+    aDN = math.sin((P * (self.DE + SH)) * 180 / math.pi) - math.sin(
+        (P * (self.DS + SH)) * 180 / math.pi
     )  # denominator of the amplitude
     ampl = aN / aDN  # amplitude of new signal
 
-    self.EpHour = max(
-        ifthenelse(
-            pcrand(x >= self.DS, x <= self.DE),
-            -1 * ampl * cos((P * (x + SH)) * 180 / pi),
+    self.EpHour = math.max(
+        pcr.ifthenelse(
+            pcr.pcrand(x >= self.DS, x <= self.DE),
+            -1 * ampl * math.cos((P * (x + SH)) * 180 / math.pi),
             0,
         ),
         0,
@@ -309,21 +310,21 @@ def downscale_evaporation_snow(self, k):
     - 
     """
 
-    teller = pcr2numpy(self.thestep, nan)[0, 0]
-    x = teller - floor(teller / 24) * 24 * scalar(self.catchArea)
+    teller = pcr.pcr2numpy(self.thestep, np.nan)[0, 0]
+    x = teller - math.floor(teller / 24) * 24 * pcr.scalar(self.catchArea)
     DL = self.DE - self.DS + 1
-    P = 2 * pi / (2 * DL)  # period
+    P = 2 * math.pi / (2 * DL)  # period
     SH = DL - 12  # horizontal shift of new signal
     aN = -1 * self.EpDaySnow * P  # nominator of the amplitude
-    aDN = sin((P * (self.DE + SH)) * 180 / pi) - sin(
-        (P * (self.DS + SH)) * 180 / pi
+    aDN = math.sin((P * (self.DE + SH)) * 180 / math.pi) - math.sin(
+        (P * (self.DS + SH)) * 180 / math.pi
     )  # denominator of the amplitude
     ampl = aN / aDN  # amplitude of new signal
 
-    self.EpHour = max(
-        ifthenelse(
-            pcrand(x >= self.DS, x <= self.DE),
-            -1 * ampl * cos((P * (x + SH)) * 180 / pi),
+    self.EpHour = pcr.max(
+        pcr.ifthenelse(
+            pcr.pcrand(x >= self.DS, x <= self.DE),
+            -1 * ampl * math.cos((P * (x + SH)) * 180 / math.pi),
             0,
         ),
         0,

--- a/wflow/__init__.py
+++ b/wflow/__init__.py
@@ -6,7 +6,9 @@ __all__ = [
     "wf_DynamicFramework",
     "stats",
 ]
-import os, sys
+import os
+import sys
+
 import osgeo.gdal as gdal
 
 if getattr(sys, "frozen", False):

--- a/wflow/__init__.py
+++ b/wflow/__init__.py
@@ -28,5 +28,6 @@ if getattr(sys, "frozen", False):
     os.environ["PROJ_DIR"] = os.path.join(basedir, "proj-data")
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+
+__version__ = get_versions()["version"]
 del get_versions

--- a/wflow/_version.py
+++ b/wflow/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/wflow/ogr2ogr.py
+++ b/wflow/ogr2ogr.py
@@ -35,13 +35,14 @@
 # Note : this is the most direct port of ogr2ogr.cpp possible
 # It could be made much more Python'ish !
 
-import sys
 import os
 import stat
+import sys
 
 from osgeo import gdal
 from osgeo import ogr
 from osgeo import osr
+
 
 ###############################################################################
 

--- a/wflow/ops_scalar2grid.py
+++ b/wflow/ops_scalar2grid.py
@@ -17,12 +17,8 @@ ops_scalar2grid  -C case -R Runid -c inifile
 
 """
 
-import getopt
-
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-
-# import scipy
 
 
 def usage(*args):

--- a/wflow/ops_scalar2grid.py
+++ b/wflow/ops_scalar2grid.py
@@ -17,6 +17,7 @@ ops_scalar2grid  -C case -R Runid -c inifile
 
 """
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -29,7 +30,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. This is your work!
   """
@@ -42,8 +43,8 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
       
       """
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -153,7 +154,7 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
         self.timestepsecs = int(
             configget(self.config, "model", "timestepsecs", "86400")
@@ -186,7 +187,7 @@ class WflowModel(DynamicModel):
         except:
             self.logger.warning("Cannot load initial states, setting to default")
             for s in self.stateVariables():
-                exec("self." + s + " = cover(1.0)")
+                exec("self." + s + " = pcr.cover(1.0)")
 
     def default_summarymaps(self):
         """
@@ -207,21 +208,21 @@ class WflowModel(DynamicModel):
 
         self.wf_updateparameters()  # read the temperature map for each step (see parameters())
 
-        self.Stations = ordinal(self.Stations)
+        self.Stations = pcr.ordinal(self.Stations)
 
         for var in self.ToInterpolate:
             tss = configget(self.config, "interpolate", var, None)
-            tmp = timeinputscalar(self.Dir + "/" + tss, self.Stations)
+            tmp = pcr.timeinputscalar(self.Dir + "/" + tss, self.Stations)
 
             if self.interpolationmethod == "thiessen":
-                Unq = uniqueid(boolean(abs(tmp) + 1.0))
-                GaugeArea = spreadzone(ordinal(cover(Unq, 0)), 0, 1)
-                exec("self." + var + " = areaaverage(tmp,GaugeArea)")
+                Unq = pcr.uniqueid(pcr.boolean(abs(tmp) + 1.0))
+                GaugeArea = spreadzone(pcr.ordinal(pcr.cover(Unq, 0)), 0, 1)
+                exec("self." + var + " = pcr.areaaverage(tmp,GaugeArea)")
             elif self.interpolationmethod == "inverse":
                 exec(
                     "self."
                     + var
-                    + "=inversedistance(1,tmp,"
+                    + "=pcr.inversedistance(1,tmp,"
                     + str(self.inversepower)
                     + ",0,0)"
                 )

--- a/wflow/pcrglobwb/groundwater.py
+++ b/wflow/pcrglobwb/groundwater.py
@@ -23,9 +23,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import math
+import os
 
-from pcraster.framework import *
-from wflow.wf_DynamicFramework import configget
+import pcraster as pcr
+from wflow.wf_DynamicFramework import configget, configset
 
 from .ncConverter import *
 
@@ -924,7 +926,7 @@ class Groundwater(object):
 
             # factor for perturbing the initial storGroundwater
             self.storGroundwater = self.storGroundwater * (
-                mapnormal() * parameters["standard_deviation"] + 1
+                pcr.mapnormal() * parameters["standard_deviation"] + 1
             )
             self.storGroundwater = pcr.max(0.0, self.storGroundwater)
 
@@ -1167,7 +1169,7 @@ class Groundwater(object):
                     self.netcdfObj.data2NetCDF(
                         str(self.outNCDir) + "/" + str(var) + "_dailyTot.nc",
                         var,
-                        pcr2numpy(self.__getattribute__(var), vos.MV),
+                        pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                         timeStamp,
                         timestepPCR - 1,
                     )
@@ -1190,7 +1192,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthTot.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -1215,7 +1217,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthAvg.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -1228,7 +1230,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthEnd.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -1251,7 +1253,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaTot.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -1275,7 +1277,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaAvg.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -1288,7 +1290,7 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaEnd.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )

--- a/wflow/pcrglobwb/groundwater.py
+++ b/wflow/pcrglobwb/groundwater.py
@@ -1192,7 +1192,9 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthTot.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "MonthTot"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -1217,7 +1219,9 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthAvg.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "MonthAvg"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -1253,7 +1257,9 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaTot.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "AnnuaTot"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -1277,7 +1283,9 @@ class Groundwater(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaAvg.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "AnnuaAvg"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )

--- a/wflow/pcrglobwb/groundwater.py
+++ b/wflow/pcrglobwb/groundwater.py
@@ -22,20 +22,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import math
-import os
-
-from pcraster.framework import *
-import pcraster as pcr
-
 import logging
 
-logger = logging.getLogger("wflow_pcrglobwb")
+from pcraster.framework import *
+from wflow.wf_DynamicFramework import configget
 
-from . import virtualOS as vos
 from .ncConverter import *
 
-from wflow.wf_DynamicFramework import configget
+logger = logging.getLogger("wflow_pcrglobwb")
 
 
 class Groundwater(object):

--- a/wflow/pcrglobwb/landCover.py
+++ b/wflow/pcrglobwb/landCover.py
@@ -1908,7 +1908,7 @@ class LandCover(object):
                 )
                 ** 0.25,
             )
-            # KTHVERT = min(sqrt(KTHEFF1*KTHEFF2),(KTHEFF1*KTHEFF2*KTHEFF1_FC*KTHEFF2_FC)**0.25)
+            # KTHVERT = min(pcr.sqrt(KTHEFF1*KTHEFF2),(KTHEFF1*KTHEFF2*KTHEFF1_FC*KTHEFF2_FC)**0.25)
 
             # gradient for capillary rise (index indicating target store to its underlying store)
             self.gradientUppLow = pcr.max(
@@ -3853,7 +3853,7 @@ class LandCover(object):
                 pcr.sqrt(self.kUnsatLow * self.parameters.kUnsatAtFieldCapLow),
             )
             # original Rens's line:
-            #    P2_L[TYPE] = min(KTHEFF2,sqrt(KTHEFF2*KTHEFF2_FC[TYPE]))*Duration*timeslice()
+            #    P2_L[TYPE] = min(KTHEFF2,pcr.sqrt(KTHEFF2*KTHEFF2_FC[TYPE]))*Duration*timeslice()
 
             # - capillary rise to storUpp from storLow
             self.capRiseUpp = pcr.min(

--- a/wflow/pcrglobwb/landCover.py
+++ b/wflow/pcrglobwb/landCover.py
@@ -23,16 +23,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import pcraster as pcr
-
 import logging
 
-logger = logging.getLogger("wflow_pcrglobwb")
+from wflow.wf_DynamicFramework import configget
 
-from . import virtualOS as vos
 from .ncConverter import *
 
-from wflow.wf_DynamicFramework import configget
+logger = logging.getLogger("wflow_pcrglobwb")
 
 
 class LandCover(object):

--- a/wflow/pcrglobwb/landSurface.py
+++ b/wflow/pcrglobwb/landSurface.py
@@ -978,7 +978,8 @@ class LandSurface(object):
         window_size = 1.25 * pcr.clone().cellSize()
         window_size = pcr.min(
             window_size,
-            pcr.min(pcr.clone().nrRows(), pcr.clone().nrCols()) * pcr.clone().cellSize(),
+            pcr.min(pcr.clone().nrRows(), pcr.clone().nrCols())
+            * pcr.clone().cellSize(),
         )
         try:
             self.irrigationEfficiency = pcr.cover(

--- a/wflow/pcrglobwb/landSurface.py
+++ b/wflow/pcrglobwb/landSurface.py
@@ -22,21 +22,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pcraster as pcr
-from . import virtualOS as vos
-
 import logging
+import os
 
-logger = logging.getLogger("wflow_pcrglobwb")
-
-from .ncConverter import *
+from wflow.wf_DynamicFramework import configget
+from wflow.wf_DynamicFramework import configsection
 
 from . import landCover as lc
 from . import parameterSoilAndTopo as parSoilAndTopo
+from .ncConverter import *
 
-import os
-from wflow.wf_DynamicFramework import configsection
-from wflow.wf_DynamicFramework import configget
+logger = logging.getLogger("wflow_pcrglobwb")
 
 
 class LandSurface(object):

--- a/wflow/pcrglobwb/landSurface.py
+++ b/wflow/pcrglobwb/landSurface.py
@@ -976,9 +976,9 @@ class LandSurface(object):
         )
         # extrapolate efficiency map:                                                # TODO: Make a better extrapolation algorithm (considering cell size, etc.).
         window_size = 1.25 * pcr.clone().cellSize()
-        window_size = min(
+        window_size = pcr.min(
             window_size,
-            min(pcr.clone().nrRows(), pcr.clone().nrCols()) * pcr.clone().cellSize(),
+            pcr.min(pcr.clone().nrRows(), pcr.clone().nrCols()) * pcr.clone().cellSize(),
         )
         try:
             self.irrigationEfficiency = pcr.cover(

--- a/wflow/pcrglobwb/ncConverter.py
+++ b/wflow/pcrglobwb/ncConverter.py
@@ -23,11 +23,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-import netCDF4 as nc
+
 import cftime
+import netCDF4 as nc
 import numpy as np
 import pcraster as pcr
+
 from . import virtualOS as vos
+
 
 # TODO: defined the dictionary (e.g. filecache = dict()) to avoid open and closing files
 

--- a/wflow/pcrglobwb/parameterSoilAndTopo.py
+++ b/wflow/pcrglobwb/parameterSoilAndTopo.py
@@ -24,10 +24,10 @@
 
 
 import pcraster as pcr
-from . import virtualOS as vos
-
-from wflow.wflow_lib import configsection
 from wflow.wflow_lib import configget
+from wflow.wflow_lib import configsection
+
+from . import virtualOS as vos
 
 
 class SoilAndTopoParameters(object):

--- a/wflow/pcrglobwb/routing.py
+++ b/wflow/pcrglobwb/routing.py
@@ -22,22 +22,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
-from pcraster.framework import *
-import pcraster as pcr
-
 import logging
 
-logger = logging.getLogger("wflow_pcrglobwb")
-
-from . import virtualOS as vos
-from .ncConverter import *
-
-from . import waterBodies
-
+from pcraster.framework import *
 from wflow.wf_DynamicFramework import configget
 from wflow.wflow_lib import getgridparams
+
+from . import waterBodies
+from .ncConverter import *
+
+logger = logging.getLogger("wflow_pcrglobwb")
 
 
 class Routing(object):

--- a/wflow/pcrglobwb/routing.py
+++ b/wflow/pcrglobwb/routing.py
@@ -2448,7 +2448,9 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthTot.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "MonthTot"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -2473,7 +2475,9 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthAvg.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "MonthAvg"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -2509,7 +2513,9 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaTot.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "AnnuaTot"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -2533,7 +2539,9 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaAvg.nc",
                             var,
-                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
+                            pcr.pcr2numpy(
+                                self.__getattribute__(var + "AnnuaAvg"), vos.MV
+                            ),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )

--- a/wflow/pcrglobwb/routing.py
+++ b/wflow/pcrglobwb/routing.py
@@ -23,8 +23,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 
-from pcraster.framework import *
+import pcraster as pcr
 from wflow.wf_DynamicFramework import configget
 from wflow.wflow_lib import getgridparams
 
@@ -2424,7 +2425,7 @@ class Routing(object):
                     self.netcdfObj.data2NetCDF(
                         str(self.outNCDir) + "/" + str(var) + "_dailyTot.nc",
                         var,
-                        pcr2numpy(self.__getattribute__(var), vos.MV),
+                        pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                         timeStamp,
                         timestepPCR - 1,
                     )
@@ -2447,7 +2448,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthTot.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "MonthTot"), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -2472,7 +2473,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthAvg.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "MonthAvg"), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -2485,7 +2486,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_monthEnd.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                             timeStamp,
                             currTimeStep.monthIdx - 1,
                         )
@@ -2508,7 +2509,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaTot.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaTot"), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -2532,7 +2533,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaAvg.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var + "AnnuaAvg"), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )
@@ -2545,7 +2546,7 @@ class Routing(object):
                         self.netcdfObj.data2NetCDF(
                             str(self.outNCDir) + "/" + str(var) + "_annuaEnd.nc",
                             var,
-                            pcr2numpy(self.__getattribute__(var), vos.MV),
+                            pcr.pcr2numpy(self.__getattribute__(var), vos.MV),
                             timeStamp,
                             currTimeStep.annuaIdx - 1,
                         )

--- a/wflow/pcrglobwb/virtualOS.py
+++ b/wflow/pcrglobwb/virtualOS.py
@@ -25,25 +25,23 @@
 # EHS (20 March 2013): This is the list of general functions.
 #                      The list is continuation from Rens's and Dominik's.
 
+import calendar
+import datetime
+import gc
+import glob
+import logging
+import os
+import random
+import re
 import shutil
 import subprocess
-import datetime
-import random
-import os
-import gc
-import re
 import sys
-import calendar
-import glob
 
-import netCDF4 as nc
 import cftime
+import netCDF4 as nc
 import numpy as np
 import numpy.ma as ma
 import pcraster as pcr
-
-
-import logging
 
 logger = logging.getLogger("wflow_pcrglobwb")
 

--- a/wflow/pcrglobwb/virtualOS.py
+++ b/wflow/pcrglobwb/virtualOS.py
@@ -1815,7 +1815,7 @@ def waterBalance(
     # print "Water balance for %s on %s: %f mm !!! " %(processName,dateStr,maxWBError * 1000)
     # pcr.report(wb,"%s-WaterBalanceError-%s" %(processName,dateStr))
 
-    # npWBMError = pcr2numpy(wb, -9999)
+    # npWBMError = pcr.pcr2numpy(wb, -9999)
     # (nr, nc) = np.shape(npWBMError)
     # for r in range(0, nr):
     # for c in range(0, nc):

--- a/wflow/pcrglobwb/waterBodies.py
+++ b/wflow/pcrglobwb/waterBodies.py
@@ -23,15 +23,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import pcraster as pcr
-
 import logging
 
-logger = logging.getLogger("wflow_pcrglobwb")
+import pcraster as pcr
+from wflow.wf_DynamicFramework import configget
 
 from . import virtualOS as vos
 
-from wflow.wf_DynamicFramework import configget
+logger = logging.getLogger("wflow_pcrglobwb")
 
 
 class WaterBodies(object):

--- a/wflow/pcrut.py
+++ b/wflow/pcrut.py
@@ -41,7 +41,11 @@ def lattometres(lat):
         + (m3 * pcr.cos(4.0 * radlat))
         + (m4 * pcr.cos(6.0 * radlat))
     )
-    longlen = (p1 * pcr.cos(radlat)) + (p2 * pcr.cos(3.0 * radlat)) + (p3 * pcr.cos(5.0 * radlat))
+    longlen = (
+        (p1 * pcr.cos(radlat))
+        + (p2 * pcr.cos(3.0 * radlat))
+        + (p3 * pcr.cos(5.0 * radlat))
+    )
 
     return latlen, longlen
 

--- a/wflow/pcrut.py
+++ b/wflow/pcrut.py
@@ -7,9 +7,11 @@ PCRaster python bindings.
 import logging
 import logging.handlers
 import os.path
-from math import *
+import math
+import sys
 
-from pcraster.framework import *
+import numpy
+import pcraster as pcr
 
 
 def lattometres(lat):
@@ -19,10 +21,10 @@ def lattometres(lat):
     Input: map with lattitude values for each cell
     Returns: length of a cell lat, length of a cell long
     """
-    # radlat = spatial(lat * ((2.0 * math.pi)/360.0))
+    # radlat = pcr.spatial(lat * ((2.0 * math.pi)/360.0))
     # radlat = lat * (2.0 * math.pi)/360.0
-    setglobaloption("degrees")
-    radlat = spatial(lat)  # pcraster cos/sin work in degrees!
+    pcr.setglobaloption("degrees")
+    radlat = pcr.spatial(lat)  # pcraster cos/sin work in degrees!
 
     m1 = 111132.92  # latitude calculation term 1
     m2 = -559.82  # latitude calculation term 2
@@ -35,11 +37,11 @@ def lattometres(lat):
 
     latlen = (
         m1
-        + (m2 * cos(2.0 * radlat))
-        + (m3 * cos(4.0 * radlat))
-        + (m4 * cos(6.0 * radlat))
+        + (m2 * pcr.cos(2.0 * radlat))
+        + (m3 * pcr.cos(4.0 * radlat))
+        + (m4 * pcr.cos(6.0 * radlat))
     )
-    longlen = (p1 * cos(radlat)) + (p2 * cos(3.0 * radlat)) + (p3 * cos(5.0 * radlat))
+    longlen = (p1 * pcr.cos(radlat)) + (p2 * pcr.cos(3.0 * radlat)) + (p3 * pcr.cos(5.0 * radlat))
 
     return latlen, longlen
 
@@ -51,15 +53,15 @@ def detRealCellLength(ZeroMap, sizeinmetres):
     """
 
     if sizeinmetres:
-        reallength = celllength()
-        xl = celllength()
-        yl = celllength()
+        reallength = pcr.celllength()
+        xl = pcr.celllength()
+        yl = pcr.celllength()
     else:
-        aa = ycoordinate(boolean(cover(ZeroMap + 1, 1)))
+        aa = pcr.ycoordinate(pcr.boolean(pcr.cover(ZeroMap + 1, 1)))
         yl, xl = lattometres(aa)
 
-        xl = xl * celllength()
-        yl = yl * celllength()
+        xl = xl * pcr.celllength()
+        yl = yl * pcr.celllength()
         # Average length for surface area calculations.
 
         reallength = (xl + yl) * 0.5
@@ -113,9 +115,9 @@ def readmapSave(pathtomap, default):
     Adpatation of readmap that returns a default map if the map cannot be found
     """
     if os.path.isfile(pathtomap):
-        return readmap(pathtomap)
+        return pcr.readmap(pathtomap)
     else:
-        return scalar(default)
+        return pcr.scalar(default)
 
 
 def readtss(nname):
@@ -175,15 +177,15 @@ def interpolategauges(inputmap, method):
     """
 
     if method == "inv":
-        result = inversedistance(1, inputmap, 3, 0, 0)
+        result = pcr.inversedistance(1, inputmap, 3, 0, 0)
     elif method == "pol":
-        Unq = uniqueid(boolean(inputmap + 1))
-        result = spreadzone(ordinal(cover(Unq, 0)), 0, 1)
-        result = areaaverage(inputmap, result)
+        Unq = pcr.uniqueid(pcr.boolean(inputmap + 1))
+        result = pcr.spreadzone(pcr.ordinal(pcr.cover(Unq, 0)), 0, 1)
+        result = pcr.areaaverage(inputmap, result)
     else:
-        Unq = uniqueid(boolean(inputmap + 1))
-        result = spreadzone(ordinal(cover(Unq, 0)), 0, 1)
-        result = areaaverage(inputmap, result)
+        Unq = pcr.uniqueid(pcr.boolean(inputmap + 1))
+        result = pcr.spreadzone(pcr.ordinal(pcr.cover(Unq, 0)), 0, 1)
+        result = pcr.areaaverage(inputmap, result)
 
     return result
 
@@ -244,6 +246,6 @@ def tableToMapSparse(step, table, map):
     else:
         fname_map = map + str(tableToMapSparse._tableToMap_LastMap[map]) + ".map"
 
-    rmat = lookupscalar(str(fname_tbl), str(fname_map))
+    rmat = pcr.lookupscalar(str(fname_tbl), str(fname_map))
 
     return rmat

--- a/wflow/pcrut.py
+++ b/wflow/pcrut.py
@@ -4,17 +4,12 @@ PCRaster python bindings.
 
 """
 
-import os.path
-import numpy
-from math import *
-import sys
-from pcraster import *
-
-
-from pcraster import *
-from pcraster.framework import *
 import logging
 import logging.handlers
+import os.path
+from math import *
+
+from pcraster.framework import *
 
 
 def lattometres(lat):

--- a/wflow/plottss.py
+++ b/wflow/plottss.py
@@ -30,10 +30,10 @@ syntax:
 
 """
 
-from wflow.pcrut import *
-
 import getopt
+
 from pylab import *
+from wflow.pcrut import *
 
 
 def usage(*args):

--- a/wflow/reservoir_Sa.py
+++ b/wflow/reservoir_Sa.py
@@ -69,7 +69,7 @@ def agriZone_no_reservoir(self, k):
     self.Qa_[k] = 0.0
     self.Ea_[k] = 0.0
     self.Sa[k] = 0.0
-    self.Fa_[k] = max(self.Pe_[k], 0)
+    self.Fa_[k] = pcr.max(self.Pe_[k], 0)
     self.wbSa_[k] = (
         self.Pe_[k]
         - self.Ea_[k]
@@ -90,9 +90,9 @@ def agriZone_Jarvis(self, k):
     - Qa u is determined from overflow from Sa
     - Code for ini-file: 1
     """
-    self.Qa = max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
+    self.Qa = pcr.max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
     JarvisCoefficients.calcEu(
@@ -105,20 +105,20 @@ def agriZone_Jarvis(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Fa = (
         self.Fa1
-        + (self.Fa1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Fa1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Ea = (
         self.Ea1
-        + (self.Ea1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Ea1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Ea - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = self.Pe - self.Ea - self.Qa - self.Fa - self.Sa[k] + self.Sa_t[k]
 
@@ -138,14 +138,14 @@ def agriZone_Ep(self, k):
     - Code for ini-file: 2
     """
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Qa = max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
+    self.Qa = pcr.max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax[k] * self.LP[k]), 1
     )
 
@@ -154,20 +154,20 @@ def agriZone_Ep(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Fa = (
         self.Fa1
-        + (self.Fa1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Fa1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Ea = (
         self.Ea1
-        + (self.Ea1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Ea1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Ea - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = self.Pe - self.Ea - self.Qa - self.Fa - self.Sa[k] + self.Sa_t[k]
 
@@ -188,18 +188,18 @@ def agriZone_Ep_Sa(self, k):
     - Code for ini-file: 3
     """
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Qa = max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
+    self.Qa = pcr.max(self.Pe - (self.samax[k] - self.Sa_t[k]), 0)
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax[k] * self.LP[k]), 1
     )
 
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -207,20 +207,20 @@ def agriZone_Ep_Sa(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Fa = (
         self.Fa1
-        + (self.Fa1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Fa1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Ea = (
         self.Ea1
-        + (self.Ea1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Ea1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Ea - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = self.Pe - self.Ea - self.Qa - self.Fa - self.Sa[k] + self.Sa_t[k]
 
@@ -241,21 +241,21 @@ def agriZone_Ep_Sa_cropG(self, k):
     - Code for ini-file: 4
     """
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
     self.samax2 = self.samax[k] * self.cropG
-    self.Qaadd = max(self.Sa_t[k] - self.samax2, 0)
+    self.Qaadd = pcr.max(self.Sa_t[k] - self.samax2, 0)
 
-    self.Qa = max(self.Pe - (self.samax2 - self.Sa_t[k]), 0) + self.Qaadd
+    self.Qa = pcr.max(self.Pe - (self.samax2 - self.Sa_t[k]), 0) + self.Qaadd
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
 
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -263,20 +263,20 @@ def agriZone_Ep_Sa_cropG(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Fa = (
         self.Fa1
-        + (self.Fa1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Fa1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Ea = (
         self.Ea1
-        + (self.Ea1 / ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
+        + (self.Ea1 / pcr.ifthenelse(self.Fa1 + self.Ea1 > 0, self.Fa1 + self.Ea1, 1))
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qa) - self.Ea - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = self.Pe - self.Ea - self.Qa - self.Fa - self.Sa[k] + self.Sa_t[k]
 
@@ -298,20 +298,20 @@ def agriZone_Ep_Sa_cropG_beta(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
     self.samax2 = self.samax[k] * self.cropG
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -319,12 +319,12 @@ def agriZone_Ep_Sa_cropG_beta(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -334,7 +334,7 @@ def agriZone_Ep_Sa_cropG_beta(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -344,15 +344,15 @@ def agriZone_Ep_Sa_cropG_beta(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -376,20 +376,20 @@ def agriZone_Ep_Sa_beta(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(max(self.Sa[k] / self.samax2, 0), 1)
+    self.SaN = pcr.min(pcr.max(self.Sa[k] / self.samax2, 0), 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -397,12 +397,12 @@ def agriZone_Ep_Sa_beta(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -412,7 +412,7 @@ def agriZone_Ep_Sa_beta(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -422,15 +422,15 @@ def agriZone_Ep_Sa_beta(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -454,20 +454,20 @@ def agriZone_hourlyEp_Sa_beta(self, k):
     """
 
     # JarvisCoefficients.calcEp(self,k)
-    # self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0),0)
+    # self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0),0)
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(max(self.Sa[k] / self.samax2, 0), 1)
+    self.SaN = pcr.min(pcr.max(self.Sa[k] / self.samax2, 0), 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -475,12 +475,12 @@ def agriZone_hourlyEp_Sa_beta(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -490,7 +490,7 @@ def agriZone_hourlyEp_Sa_beta(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -500,15 +500,15 @@ def agriZone_hourlyEp_Sa_beta(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -535,31 +535,31 @@ def agriZone_Ep_Sa_beta_frost(self, k):
     JarvisCoefficients.calcEp(self, k)
     self.PotEvaporation = self.EpHour
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
-    self.FrDur[k] = min(
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.FrDur[k] = pcr.min(
         self.FrDur[k]
         + (self.Tmean - 273.15) / 86400 * self.timestepsecs * self.dayDeg[k],
         0,
     )
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Ft = min(
-        max(
+    self.Ft = pcr.min(
+        pcr.max(
             self.FrDur[k] / (self.FrDur1[k] - self.FrDur0[k])
             - self.FrDur0[k] / (self.FrDur1[k] - self.FrDur0[k]),
             0,
         ),
         1,
     )
-    self.Fa1 = self.Ft * ifthenelse(
+    self.Fa1 = self.Ft * pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -568,12 +568,12 @@ def agriZone_Ep_Sa_beta_frost(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -583,7 +583,7 @@ def agriZone_Ep_Sa_beta_frost(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -593,15 +593,15 @@ def agriZone_Ep_Sa_beta_frost(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -629,30 +629,30 @@ def agriZone_hourlyEp_Sa_beta_frost(self, k):
     # JarvisCoefficients.calcEp(self,k)
     # self.PotEvaporation = self.EpHour
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
-    self.FrDur[k] = min(
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.FrDur[k] = pcr.min(
         self.FrDur[k] + (self.Temperature) / 86400 * self.timestepsecs * self.dayDeg[k],
         0,
     )
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Ft = min(
-        max(
+    self.Ft = pcr.min(
+        pcr.max(
             self.FrDur[k] / (self.FrDur1[k] - self.FrDur0[k])
             - self.FrDur0[k] / (self.FrDur1[k] - self.FrDur0[k]),
             0,
         ),
         1,
     )
-    self.Fa1 = self.Ft * ifthenelse(
+    self.Fa1 = self.Ft * pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -661,12 +661,12 @@ def agriZone_hourlyEp_Sa_beta_frost(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -676,7 +676,7 @@ def agriZone_hourlyEp_Sa_beta_frost(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -686,15 +686,15 @@ def agriZone_hourlyEp_Sa_beta_frost(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -722,9 +722,9 @@ def agriZone_hourlyEp_Sa_beta_frostSamax(self, k):
     # JarvisCoefficients.calcEp(self,k)
     # self.PotEvaporation = self.EpHour
 
-    self.FrDur[k] = min(self.FrDur[k] + (self.Temperature) * self.dayDeg[k], 0)
-    self.Ft = min(
-        max(
+    self.FrDur[k] = pcr.min(self.FrDur[k] + (self.Temperature) * self.dayDeg[k], 0)
+    self.Ft = pcr.min(
+        pcr.max(
             self.FrDur[k] / (self.FrDur1[k] - self.FrDur0[k])
             - self.FrDur0[k] / (self.FrDur1[k] - self.FrDur0[k]),
             0.1,
@@ -732,18 +732,18 @@ def agriZone_hourlyEp_Sa_beta_frostSamax(self, k):
         1,
     )
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea) * self.Ft
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea) * self.Ft
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -752,12 +752,12 @@ def agriZone_hourlyEp_Sa_beta_frostSamax(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -767,7 +767,7 @@ def agriZone_hourlyEp_Sa_beta_frostSamax(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -777,15 +777,15 @@ def agriZone_hourlyEp_Sa_beta_frostSamax(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -811,18 +811,18 @@ def agriZone_Ep_Sa_beta_frostSamax(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.FrDur[k] = min(
+    self.FrDur[k] = pcr.min(
         self.FrDur[k]
-        + ifthenelse(
+        + pcr.ifthenelse(
             self.Temperature > 0, self.ratFT[k] * self.Temperature, self.Temperature
         )
         * self.dayDeg[k],
         0,
     )
-    self.Ft = min(
-        max(
+    self.Ft = pcr.min(
+        pcr.max(
             self.FrDur[k] / (self.FrDur1[k] - self.FrDur0[k])
             - self.FrDur0[k] / (self.FrDur1[k] - self.FrDur0[k]),
             self.samin[k],
@@ -830,19 +830,19 @@ def agriZone_Ep_Sa_beta_frostSamax(self, k):
         1,
     )
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea) * self.Ft
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea) * self.Ft
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
 
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -851,12 +851,12 @@ def agriZone_Ep_Sa_beta_frostSamax(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -866,7 +866,7 @@ def agriZone_Ep_Sa_beta_frostSamax(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -876,15 +876,15 @@ def agriZone_Ep_Sa_beta_frostSamax(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -912,14 +912,14 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
     JarvisCoefficients.calcEp(self, k)
     self.PotEvaporation = self.EpHour
 
-    self.FrDur[k] = min(
+    self.FrDur[k] = pcr.min(
         self.FrDur[k]
-        + ifthenelse(self.TempSurf > 0, self.ratFT[k] * self.TempSurf, self.TempSurf)
+        + pcr.ifthenelse(self.TempSurf > 0, self.ratFT[k] * self.TempSurf, self.TempSurf)
         * self.dayDeg[k],
         0,
     )
-    self.Ft = min(
-        max(
+    self.Ft = pcr.min(
+        pcr.max(
             self.FrDur[k] / (self.FrDur1[k] - self.FrDur0[k])
             - self.FrDur0[k] / (self.FrDur1[k] - self.FrDur0[k]),
             self.samin[k],
@@ -927,19 +927,19 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
         1,
     )
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea) * self.Ft
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea) * self.Ft
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
 
-    self.Fa1 = ifthenelse(
+    self.Fa1 = pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -948,12 +948,12 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -963,7 +963,7 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -973,15 +973,15 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -1008,18 +1008,18 @@ def agriZone_Ep_Sa_beta_Fvar(self, k):
     JarvisCoefficients.calcEp(self, k)
     self.PotEvaporation = self.EpHour
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = self.cropG * ifthenelse(
+    self.Fa1 = self.cropG * pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -1027,12 +1027,12 @@ def agriZone_Ep_Sa_beta_Fvar(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -1042,7 +1042,7 @@ def agriZone_Ep_Sa_beta_Fvar(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -1052,15 +1052,15 @@ def agriZone_Ep_Sa_beta_Fvar(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]
@@ -1086,18 +1086,18 @@ def agriZone_hourlyEp_Sa_beta_Fvar(self, k):
     #    JarvisCoefficients.calcEp(self,k)
     #    self.PotEvaporation = self.EpHour
 
-    self.samax2 = self.samax[k] * scalar(self.catchArea)
-    self.Qaadd = max(self.Sa_t[k] + self.Pe - self.samax2, 0)
+    self.samax2 = self.samax[k] * pcr.scalar(self.catchArea)
+    self.Qaadd = pcr.max(self.Sa_t[k] + self.Pe - self.samax2, 0)
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd)
-    self.SaN = min(self.Sa[k] / self.samax2, 1)
+    self.SaN = pcr.min(self.Sa[k] / self.samax2, 1)
     self.SuN = self.Su[k] / self.sumax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax2 * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
-    self.Fa1 = self.cropG * ifthenelse(
+    self.Fa1 = self.cropG * pcr.ifthenelse(
         self.SaN > 0,
         self.Fmin[k]
         + (self.Fmax[k] - self.Fmin[k]) * e ** (-self.decF[k] * (1 - self.SaN)),
@@ -1105,12 +1105,12 @@ def agriZone_hourlyEp_Sa_beta_Fvar(self, k):
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Fa1 - self.Ea1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -1120,7 +1120,7 @@ def agriZone_hourlyEp_Sa_beta_Fvar(self, k):
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
@@ -1130,15 +1130,15 @@ def agriZone_hourlyEp_Sa_beta_Fvar(self, k):
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Fa1 + self.Ea1 + self.Qa1 > 0, self.Fa1 + self.Ea1 + self.Qa1, 1
             )
         )
         * self.Sa_diff
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Fa - self.Qa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
     self.wbSa_[k] = (
         self.Pe - self.Ea - self.Qa - self.Qaadd - self.Fa - self.Sa[k] + self.Sa_t[k]

--- a/wflow/reservoir_Sa.py
+++ b/wflow/reservoir_Sa.py
@@ -914,7 +914,9 @@ def agriZone_Ep_Sa_beta_frostSamax_surfTemp(self, k):
 
     self.FrDur[k] = pcr.min(
         self.FrDur[k]
-        + pcr.ifthenelse(self.TempSurf > 0, self.ratFT[k] * self.TempSurf, self.TempSurf)
+        + pcr.ifthenelse(
+            self.TempSurf > 0, self.ratFT[k] * self.TempSurf, self.TempSurf
+        )
         * self.dayDeg[k],
         0,
     )

--- a/wflow/reservoir_Sf.py
+++ b/wflow/reservoir_Sf.py
@@ -71,7 +71,9 @@ def fastRunoff_lag2(self, k):
     """
 
     if self.FR_L:
-        self.Qu = pcr.areatotal(self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Qu = pcr.areatotal(
+            self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
     else:
         self.Qu = self.Qu_[k]
 
@@ -140,8 +142,12 @@ def fastRunoff_lag_forAgri_combined(self, k):
     """
 
     if self.FR_L:
-        self.Qu = pcr.areatotal(self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId))
-        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Qu = pcr.areatotal(
+            self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
+        self.Qa = pcr.areatotal(
+            self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
     else:
         self.Qu = self.Qu_[k]
         self.Qa = self.Qa_[k]
@@ -203,7 +209,9 @@ def fastRunoff_lag_agriDitch(self, k):
     """
 
     if self.FR_L:
-        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Qa = pcr.areatotal(
+            self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
     else:
         self.Qa = self.Qa_[k]
 
@@ -262,7 +270,9 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
     """
 
     if self.FR_L:
-        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Qa = pcr.areatotal(
+            self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
     else:
         self.Qa = self.Qa_[k]
 
@@ -271,7 +281,9 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
     if self.convQa[k]:
         self.QfainLag = self.convQa[k][-1]
         self.Qfa = self.Sfa[k] * self.Kfa[k]
-        self.Percfa = pcr.ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
+        self.Percfa = pcr.ifthenelse(
+            self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0
+        )
         self.Sfa[k] = self.Sfa[k] + self.QfainLag - self.Qfa - self.Percfa
 
         self.convQa[k].insert(
@@ -289,7 +301,9 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
 
     else:
         self.Qfa = self.Sfa[k] * self.Kfa[k]
-        self.Percfa = pcr.ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
+        self.Percfa = pcr.ifthenelse(
+            self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0
+        )
         self.Sfa[k] = self.Sfa[k] + self.Qfain - self.Qfa - self.Percfa
 
     self.wbSfa_[k] = (

--- a/wflow/reservoir_Sf.py
+++ b/wflow/reservoir_Sf.py
@@ -71,7 +71,7 @@ def fastRunoff_lag2(self, k):
     """
 
     if self.FR_L:
-        self.Qu = areatotal(self.Qu_[k] * self.percentArea, nominal(self.TopoId))
+        self.Qu = pcr.areatotal(self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId))
     else:
         self.Qu = self.Qu_[k]
 
@@ -84,9 +84,9 @@ def fastRunoff_lag2(self, k):
             self.Sf[k] = self.Sf[k] + self.QfinLag - self.Qf
 
             self.convQu[k].insert(
-                0, 0 * scalar(self.catchArea)
+                0, 0 * pcr.scalar(self.catchArea)
             )  # convolution Qu for following time steps
-            self.Tfmap = self.Tf[k] * scalar(self.catchArea)
+            self.Tfmap = self.Tf[k] * pcr.scalar(self.catchArea)
             del self.convQu[k][-1]
             temp = [
                 self.convQu[k][i]
@@ -140,8 +140,8 @@ def fastRunoff_lag_forAgri_combined(self, k):
     """
 
     if self.FR_L:
-        self.Qu = areatotal(self.Qu_[k] * self.percentArea, nominal(self.TopoId))
-        self.Qa = areatotal(self.Qa_[k] * self.percentArea, nominal(self.TopoId))
+        self.Qu = pcr.areatotal(self.Qu_[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
     else:
         self.Qu = self.Qu_[k]
         self.Qa = self.Qa_[k]
@@ -155,9 +155,9 @@ def fastRunoff_lag_forAgri_combined(self, k):
             self.Sf[k] = self.Sf[k] + self.QfinLag - self.Qf
 
             self.convQu[k].insert(
-                0, 0 * scalar(self.catchArea)
+                0, 0 * pcr.scalar(self.catchArea)
             )  # convolution Qu for following time steps
-            self.Tfmap = self.Tf[k] * scalar(self.catchArea)
+            self.Tfmap = self.Tf[k] * pcr.scalar(self.catchArea)
             del self.convQu[k][-1]
             temp = [
                 self.convQu[k][i]
@@ -203,7 +203,7 @@ def fastRunoff_lag_agriDitch(self, k):
     """
 
     if self.FR_L:
-        self.Qa = areatotal(self.Qa_[k] * self.percentArea, nominal(self.TopoId))
+        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
     else:
         self.Qa = self.Qa_[k]
 
@@ -217,9 +217,9 @@ def fastRunoff_lag_agriDitch(self, k):
         self.Sfa[k] = self.Sfa[k] + self.QfainLag - self.Qfa
 
         self.convQa[k].insert(
-            0, 0 * scalar(self.catchArea)
+            0, 0 * pcr.scalar(self.catchArea)
         )  # convolution Qu for following time steps
-        self.Tfmap = self.Tfa[k] * scalar(self.catchArea)
+        self.Tfmap = self.Tfa[k] * pcr.scalar(self.catchArea)
         del self.convQa[k][-1]
         temp = [
             self.convQa[k][i]
@@ -262,7 +262,7 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
     """
 
     if self.FR_L:
-        self.Qa = areatotal(self.Qa_[k] * self.percentArea, nominal(self.TopoId))
+        self.Qa = pcr.areatotal(self.Qa_[k] * self.percentArea, pcr.nominal(self.TopoId))
     else:
         self.Qa = self.Qa_[k]
 
@@ -271,13 +271,13 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
     if self.convQa[k]:
         self.QfainLag = self.convQa[k][-1]
         self.Qfa = self.Sfa[k] * self.Kfa[k]
-        self.Percfa = ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
+        self.Percfa = pcr.ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
         self.Sfa[k] = self.Sfa[k] + self.QfainLag - self.Qfa - self.Percfa
 
         self.convQa[k].insert(
-            0, 0 * scalar(self.catchArea)
+            0, 0 * pcr.scalar(self.catchArea)
         )  # convolution Qu for following time steps
-        self.Tfmap = self.Tfa[k] * scalar(self.catchArea)
+        self.Tfmap = self.Tfa[k] * pcr.scalar(self.catchArea)
         del self.convQa[k][-1]
         temp = [
             self.convQa[k][i]
@@ -289,7 +289,7 @@ def fastRunoff_lag_agriDitch_reInfilt(self, k):
 
     else:
         self.Qfa = self.Sfa[k] * self.Kfa[k]
-        self.Percfa = ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
+        self.Percfa = pcr.ifthenelse(self.Ft_[k] == 1, self.Sfa[k] * self.perc[k] * 200, 0)
         self.Sfa[k] = self.Sfa[k] + self.Qfain - self.Qfa - self.Percfa
 
     self.wbSfa_[k] = (
@@ -313,23 +313,23 @@ def routingQf_combined(self):
     travel time for a calcultation cell
     """
 
-    if nansum(pcr2numpy(self.Transit, NaN)) > 0:
+    if np.nansum(pcr.pcr2numpy(self.Transit, np.nan)) > 0:
         self.Qflag = self.trackQ[0]  # first bucket is transferred to outlet
         self.trackQ.append(
-            0 * scalar(self.catchArea)
+            0 * pcr.scalar(self.catchArea)
         )  # add new bucket for present time step
         del self.trackQ[0]  # remove first bucket (transferred to outlet)
         temp = [
             self.trackQ[i]
-            + ifthenelse(
-                rounddown(self.Transit) == i * scalar(self.catchArea),
-                (self.Transit - i * scalar(self.catchArea))
+            + pcr.ifthenelse(
+                pcr.rounddown(self.Transit) == i * pcr.scalar(self.catchArea),
+                (self.Transit - i * pcr.scalar(self.catchArea))
                 * self.Qftotal
                 / 1000
                 * self.surfaceArea,
-                ifthenelse(
-                    roundup(self.Transit) == i * scalar(self.catchArea),
-                    (i * scalar(self.catchArea) - self.Transit)
+                pcr.ifthenelse(
+                    pcr.roundup(self.Transit) == i * pcr.scalar(self.catchArea),
+                    (i * pcr.scalar(self.catchArea) - self.Transit)
                     * self.Qftotal
                     / 1000
                     * self.surfaceArea,
@@ -351,8 +351,8 @@ def routingQf_combined(self):
         self.Qflag_ / self.timestepsecs
         + self.Qs_ / 1000 * self.surfaceArea / self.timestepsecs
     )
-    self.QLagTot = areatotal(
-        self.Qtlag, nominal(self.TopoId)
+    self.QLagTot = pcr.areatotal(
+        self.Qtlag, pcr.nominal(self.TopoId)
     )  # catchment total runoff with looptijd
 
 
@@ -365,7 +365,7 @@ def routingQf_Qs_grid(self):
     self.Qtotal = (
         self.Qtot / 1000 * self.surfaceArea / self.timestepsecs
     )  # total local discharge in m3/s
-    self.QtotNoRout = accuflux(self.TopoLdd, self.Qtotal)
+    self.QtotNoRout = pcr.accuflux(self.TopoLdd, self.Qtotal)
     self.Qstate_t = self.Qstate
     self.Qtest = self.Qstate + self.Qtotal
     self.Qrout = accutraveltimeflux(
@@ -381,8 +381,8 @@ def routingQf_Qs_grid(self):
     # water balance of flux routing
     self.dSdt = self.Qstate - self.Qstate_t
     self.WB_rout = (
-        accuflux(self.TopoLdd, self.Qtotal - self.dSdt) - self.Qrout
-    ) / accuflux(self.TopoLdd, self.Qtotal)
+        pcr.accuflux(self.TopoLdd, self.Qtotal - self.dSdt) - self.Qrout
+    ) / pcr.accuflux(self.TopoLdd, self.Qtotal)
 
 
 def routingQf_Qs_grid_mm(self):
@@ -392,7 +392,7 @@ def routingQf_Qs_grid_mm(self):
     """
     self.Qtot = self.Qftotal + self.Qs_  # total local discharge in mm/hour
     self.Qtotal = self.Qtot
-    self.QtotNoRout = accuflux(self.TopoLdd, self.Qtotal)
+    self.QtotNoRout = pcr.accuflux(self.TopoLdd, self.Qtotal)
     self.Qstate_t = self.Qstate
     self.Qtest = self.Qstate + self.Qtotal
     self.Qrout = accutraveltimeflux(
@@ -408,8 +408,8 @@ def routingQf_Qs_grid_mm(self):
     # water balance of flux routing
     self.dSdt = self.Qstate - self.Qstate_t
     self.WB_rout = (
-        accuflux(self.TopoLdd, self.Qtotal - self.dSdt) - self.Qrout
-    ) / accuflux(self.TopoLdd, self.Qtotal)
+        pcr.accuflux(self.TopoLdd, self.Qtotal - self.dSdt) - self.Qrout
+    ) / pcr.accuflux(self.TopoLdd, self.Qtotal)
 
 
 def kinematic_wave_routing(self):
@@ -419,11 +419,11 @@ def kinematic_wave_routing(self):
     )  # total local discharge in m3/s
     # self.Qstate_t = self.Qstate
 
-    self.Qtotal = max(0, self.Qtotal)  # no neg kin wave -- check ! TODO
+    self.Qtotal = pcr.max(0, self.Qtotal)  # no neg kin wave -- check ! TODO
     q = self.Qtotal / self.DCL
     self.OldSurfaceRunoff = self.Qstate
 
-    self.Qstate = kinematic(
+    self.Qstate = pcr.kinematic(
         self.TopoLdd,
         self.Qstate,
         q,
@@ -442,7 +442,7 @@ def kinematic_wave_routing(self):
     self.Qtlag = self.Qstate
 
     self.updateRunOff()
-    InflowKinWaveCell = upstream(self.TopoLdd, self.Qstate)
+    InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.Qstate)
     self.MassBalKinWave = (
         (self.KinWaveVolume - self.OldKinWaveVolume) / self.timestepsecs
         + InflowKinWaveCell

--- a/wflow/reservoir_Si.py
+++ b/wflow/reservoir_Si.py
@@ -34,7 +34,7 @@ def interception_no_reservoir(self, k):
     Interception evaporation = 0.
     Storage in interception = 0.
     """
-    self.Pe_[k] = max(self.Precipitation, 0)
+    self.Pe_[k] = pcr.max(self.Precipitation, 0)
     self.Ei_[k] = 0.0
     self.Si_[k] = 0.0
     self.wbSi_[k] = (
@@ -49,10 +49,10 @@ def interception_overflow2(self, k):
     - Code for ini-file: 2
     """
 
-    self.Pe = max(self.Precipitation - (self.imax[k] - self.Si_t[k]), 0)
+    self.Pe = pcr.max(self.Precipitation - (self.imax[k] - self.Si_t[k]), 0)
     self.Si[k] = self.Si_t[k] + (self.Precipitation - self.Pe)
-    self.Ei = ifthenelse(
-        self.Sw[k] == 0, min(self.PotEvaporation, self.Si[k]), 0
+    self.Ei = pcr.ifthenelse(
+        self.Sw[k] == 0, pcr.min(self.PotEvaporation, self.Si[k]), 0
     )  # ifstatement added on 3-11-2015 for snow module
     self.Si[k] = self.Si[k] - self.Ei
 
@@ -68,12 +68,12 @@ def interception_overflow2(self, k):
     self.PotEvaporation_ = self.PotEvaporation
 
     if self.URFR_L:
-        self.Ei = areatotal(self.Ei * self.percentArea, nominal(self.TopoId))
-        self.Pe = areatotal(self.Pe * self.percentArea, nominal(self.TopoId))
-        self.PotEvaporation = areatotal(
-            self.PotEvaporation * self.percentArea, nominal(self.TopoId)
+        self.Ei = pcr.areatotal(self.Ei * self.percentArea, pcr.nominal(self.TopoId))
+        self.Pe = pcr.areatotal(self.Pe * self.percentArea, pcr.nominal(self.TopoId))
+        self.PotEvaporation = pcr.areatotal(
+            self.PotEvaporation * self.percentArea, pcr.nominal(self.TopoId)
         )
-        self.Si[k] = areatotal(self.Si[k] * self.percentArea, nominal(self.TopoId))
+        self.Si[k] = pcr.areatotal(self.Si[k] * self.percentArea, pcr.nominal(self.TopoId))
 
 
 def interception_overflow_Ep(self, k):
@@ -87,13 +87,13 @@ def interception_overflow_Ep(self, k):
     JarvisCoefficients.calcEp(
         self, k
     )  # this line indicates that hourly profiles are made out of daily pot evap data based on start day (DS.tss) and day end (DE)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Pe = max(self.Precipitation - (self.imax[k] - self.Si_t[k]), 0)
+    self.Pe = pcr.max(self.Precipitation - (self.imax[k] - self.Si_t[k]), 0)
     self.Si[k] = self.Si_t[k] + (self.Precipitation - self.Pe)
-    self.Ei = ifthenelse(
+    self.Ei = pcr.ifthenelse(
         self.Sw[k] == 0,
-        min(
+        pcr.min(
             (self.PotEvaporation - (self.Ew_[k] / self.lamda * self.lamdaS)), self.Si[k]
         ),
         0,
@@ -112,9 +112,9 @@ def interception_overflow_Ep(self, k):
     self.Ep_[k] = self.EpHour
 
     if self.URFR_L:
-        self.Ei = areatotal(self.Ei * self.percentArea, nominal(self.TopoId))
-        self.Pe = areatotal(self.Pe * self.percentArea, nominal(self.TopoId))
-        self.PotEvaporation = areatotal(
-            self.PotEvaporation * self.percentArea, nominal(self.TopoId)
+        self.Ei = pcr.areatotal(self.Ei * self.percentArea, pcr.nominal(self.TopoId))
+        self.Pe = pcr.areatotal(self.Pe * self.percentArea, pcr.nominal(self.TopoId))
+        self.PotEvaporation = pcr.areatotal(
+            self.PotEvaporation * self.percentArea, pcr.nominal(self.TopoId)
         )
-        self.Si[k] = areatotal(self.Si[k] * self.percentArea, nominal(self.TopoId))
+        self.Si[k] = pcr.areatotal(self.Si[k] * self.percentArea, pcr.nominal(self.TopoId))

--- a/wflow/reservoir_Si.py
+++ b/wflow/reservoir_Si.py
@@ -73,7 +73,9 @@ def interception_overflow2(self, k):
         self.PotEvaporation = pcr.areatotal(
             self.PotEvaporation * self.percentArea, pcr.nominal(self.TopoId)
         )
-        self.Si[k] = pcr.areatotal(self.Si[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Si[k] = pcr.areatotal(
+            self.Si[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )
 
 
 def interception_overflow_Ep(self, k):
@@ -117,4 +119,6 @@ def interception_overflow_Ep(self, k):
         self.PotEvaporation = pcr.areatotal(
             self.PotEvaporation * self.percentArea, pcr.nominal(self.TopoId)
         )
-        self.Si[k] = pcr.areatotal(self.Si[k] * self.percentArea, pcr.nominal(self.TopoId))
+        self.Si[k] = pcr.areatotal(
+            self.Si[k] * self.percentArea, pcr.nominal(self.TopoId)
+        )

--- a/wflow/reservoir_Ss.py
+++ b/wflow/reservoir_Ss.py
@@ -32,8 +32,8 @@ def groundWater_no_reservoir(self):
     self.QsinTemp = sum(
         [a * b for a, b in zip(self.QsinClass, self.percent)]
     )  # fluxes are summed per cell according to percentage of class
-    self.Qsin = areatotal(
-        self.QsinTemp * self.percentArea, nominal(self.TopoId)
+    self.Qsin = pcr.areatotal(
+        self.QsinTemp * self.percentArea, pcr.nominal(self.TopoId)
     )  # areatotal is taken, according to area percentage of cell
 
     self.Qs = self.Qsin
@@ -56,18 +56,18 @@ def groundWaterCombined3(self):
     self.QsinTemp = sum(
         [a * b for a, b in zip(self.QsinClass, self.percent)]
     )  # fluxes are summed per cell according to percentage of class
-    self.Qsin = areatotal(
-        self.QsinTemp * self.percentArea, nominal(self.TopoId)
+    self.Qsin = pcr.areatotal(
+        self.QsinTemp * self.percentArea, pcr.nominal(self.TopoId)
     )  # areatotal is taken, according to area percentage of cell
 
     self.Qs = self.Ss * self.Ks[0]
-    # self.Ss = self.Ss * exp(-self.Ks[0]) + self.Qsin
+    # self.Ss = self.Ss * pcr.exp(-self.Ks[0]) + self.Qsin
 
     # add a gain/lossterm based on constant value
-    self.Gain = ifthenelse(
+    self.Gain = pcr.ifthenelse(
         self.Closure < 0.0, -min(self.Ss, -self.Closure), self.Closure
     )  # if negative, limited by storage in Ss
-    self.Ss = self.Ss * exp(-self.Ks[0]) + self.Qsin + self.Gain
+    self.Ss = self.Ss * pcr.exp(-self.Ks[0]) + self.Qsin + self.Gain
 
     self.wbSs = self.Qsin - self.Qs - self.Ss + self.Ss_t + self.Gain
 

--- a/wflow/reservoir_Su.py
+++ b/wflow/reservoir_Su.py
@@ -7,8 +7,6 @@ Created on Thu Apr 03 16:31:35 2014
 List all function versions
 """
 
-import numpy
-
 try:
     from wflow.wf_DynamicFramework import *
 except ImportError:

--- a/wflow/reservoir_Su.py
+++ b/wflow/reservoir_Su.py
@@ -211,13 +211,19 @@ def unsatZone_LP_beta_Jarvis(self, k):
     self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Qu = (
         self.Qu1
-        + (self.Qu1 / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
+        + (
+            self.Qu1
+            / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1)
+        )
         * self.Su_diff
     )
     self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
-        + (self.Perc1 / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
+        + (
+            self.Perc1
+            / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1)
+        )
         * self.Su_diff,
         self.Perc1,
     )

--- a/wflow/reservoir_Su.py
+++ b/wflow/reservoir_Su.py
@@ -72,7 +72,7 @@ def unsatZone_no_reservoir(self, k):
     Cap = 0.
     Storage in unsaturated zone = 0.
     """
-    self.Qu_[k] = max(self.Pe_[k], 0)
+    self.Qu_[k] = pcr.max(self.Pe_[k], 0)
     self.Eu_[k] = 0.0
     self.Perc_[k] = 0.0
     self.Su[k] = 0.0
@@ -91,10 +91,10 @@ def unsatZone_LP_beta(self, k):
     - Qu is determined with a beta function (same as in HBV?)
     - Code for ini-file: 1
     """
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -102,7 +102,7 @@ def unsatZone_LP_beta(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax[k] * self.LP[k]), 1
     )
 
@@ -112,12 +112,12 @@ def unsatZone_LP_beta(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -129,7 +129,7 @@ def unsatZone_LP_beta(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -137,12 +137,12 @@ def unsatZone_LP_beta(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -152,10 +152,10 @@ def unsatZone_LP_beta(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -189,10 +189,10 @@ def unsatZone_LP_beta_Jarvis(self, k):
     - Qu is determined with a beta function (same as in HBV?)
     - Code for ini-file: 12
     """
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -208,24 +208,24 @@ def unsatZone_LP_beta_Jarvis(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Qu = (
         self.Qu1
-        + (self.Qu1 / ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
+        + (self.Qu1 / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
-        + (self.Perc1 / ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
+        + (self.Perc1 / pcr.ifthenelse(self.Qu1 + self.Perc1 > 0, self.Qu1 + self.Perc1, 1))
         * self.Su_diff,
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -263,12 +263,12 @@ def unsatZone_LP_beta_Ep(self, k):
 
     # pdb.set_trace()
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -276,7 +276,7 @@ def unsatZone_LP_beta_Ep(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax[k] * self.LP[k]), 1
     )
 
@@ -286,12 +286,12 @@ def unsatZone_LP_beta_Ep(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -303,7 +303,7 @@ def unsatZone_LP_beta_Ep(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -311,12 +311,12 @@ def unsatZone_LP_beta_Ep(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -326,10 +326,10 @@ def unsatZone_LP_beta_Ep(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -366,12 +366,12 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
 
     # pdb.set_trace()
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -379,13 +379,13 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = ifthenelse(
+    self.Eu1 = pcr.ifthenelse(
         self.SiN == 1,
         0,
-        max((self.PotEvaporation), 0)
-        * min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
+        pcr.max((self.PotEvaporation), 0)
+        * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
     )
-    #    self.Eu1 = max((self.PotEvaporation),0) * min(self.Su[k] / (self.sumax[k] * self.LP[k]),1)
+    #    self.Eu1 = pcr.max((self.PotEvaporation),0) * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]),1)
 
     self.Qu1 = (self.Pe - self.Quadd) * (1 - (1 - self.SuN) ** self.beta[k])
     self.Perc1 = self.perc[k] * self.SuN
@@ -393,12 +393,12 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -410,7 +410,7 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -418,12 +418,12 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -433,10 +433,10 @@ def unsatZone_LP_beta_Ep_Ei(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -472,12 +472,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -485,7 +485,7 @@ def unsatZone_LP_beta_Ep_percD(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax[k] * self.LP[k]), 1
     )
 
@@ -496,12 +496,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -513,7 +513,7 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -521,12 +521,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -536,10 +536,10 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -573,12 +573,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -586,7 +586,7 @@ def unsatZone_LP_beta_Ep_percD(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax[k] * self.LP[k]), 1
     )
 
@@ -597,12 +597,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -614,7 +614,7 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -622,12 +622,12 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -637,10 +637,10 @@ def unsatZone_LP_beta_Ep_percD(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -674,12 +674,12 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax[k],
         self.Su_t[k] + self.Pe - self.sumax[k],
         0,
@@ -687,19 +687,19 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.drought = ifthenelse(
+    self.drought = pcr.ifthenelse(
         self.SuN < self.LP[k],
         self.TopoId,
-        ifthenelse(
-            pcrand(self.SuN < 0.8, self.drought),
+        pcr.ifthenelse(
+            pcr.pcrand(self.SuN < 0.8, self.drought),
             self.TopoId,
-            boolean(scalar(self.TopoId) * 0),
+            pcr.boolean(pcr.scalar(self.TopoId) * 0),
         ),
     )
-    self.stijg = max(
-        min(
-            scalar(
-                ifthenelse(
+    self.stijg = pcr.max(
+        pcr.min(
+            pcr.scalar(
+                pcr.ifthenelse(
                     self.drought == 1, self.stijg + self.Su_t[k] - self.Su_t2[k], 0
                 )
             ),
@@ -708,24 +708,24 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
         0,
     )
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax[k] * self.LP[k]), 1
     )
 
     self.Qu1 = (self.Pe - self.Quadd) * (1 - (1 - self.SuN) ** self.beta[k])
-    #    self.percDeep = max(10 * (1 - self.Ss / 30) * self.perc[k], 0)
+    #    self.percDeep = pcr.max(10 * (1 - self.Ss / 30) * self.perc[k], 0)
     self.percDeep = 0.8 * self.stijg * self.perc[k]
     self.Perc1 = self.perc[k] * self.SuN + self.percDeep
     self.Su[k] = (
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -737,7 +737,7 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -745,12 +745,12 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -760,10 +760,10 @@ def unsatZone_LP_beta_Ep_percDvar(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -799,9 +799,9 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.cropG_scal = pcr2numpy(self.cropG, NaN)
+    self.cropG_scal = pcr.pcr2numpy(self.cropG, np.nan)
     if any(self.cropG_scal == 1):
         self.sumax2 = self.sumax[k]
     elif any(self.cropG_scal > 0):
@@ -811,16 +811,16 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
     else:
         self.sumax2 = self.sumax[k] * self.redsu[k]
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax2, self.sumax2, self.Su_t[k] + self.Pe
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Pe > self.sumax2, self.Su_t[k] + self.Pe - self.sumax2, 0
     )
     self.SuN = self.Su[k] / self.sumax2
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax2 * self.LP[k]), 1
     )
 
@@ -830,12 +830,12 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
         self.Su_t[k] + (self.Pe - self.Quadd) - self.Qu1 - self.Eu1 - self.Perc1
     )
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -847,7 +847,7 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -855,12 +855,12 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -870,10 +870,10 @@ def unsatZone_LP_beta_Ep_cropG(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Pe - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -908,10 +908,10 @@ def unsatZone_forAgri_Jarvis(self, k):
     - inflow is infiltration from agriculture reservoir
     - Code for ini-file: 16
     """
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k],
         self.Su_t[k] + self.Fa - self.sumax[k],
         0,
@@ -928,12 +928,12 @@ def unsatZone_forAgri_Jarvis(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -945,7 +945,7 @@ def unsatZone_forAgri_Jarvis(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -953,12 +953,12 @@ def unsatZone_forAgri_Jarvis(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -968,10 +968,10 @@ def unsatZone_forAgri_Jarvis(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1004,12 +1004,12 @@ def unsatZone_forAgri_Ep(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k],
         self.Su_t[k] + self.Fa - self.sumax[k],
         0,
@@ -1017,10 +1017,10 @@ def unsatZone_forAgri_Ep(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = ifthenelse(
+    self.Eu1 = pcr.ifthenelse(
         self.Ft_[k] == 1,
-        max((self.PotEvaporation - self.Ei - self.Ea), 0)
-        * min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
+        pcr.max((self.PotEvaporation - self.Ei - self.Ea), 0)
+        * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
         0,
     )  # no transpiration in case of frozen soil. Added on 22 feb 2016
 
@@ -1028,12 +1028,12 @@ def unsatZone_forAgri_Ep(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1045,7 +1045,7 @@ def unsatZone_forAgri_Ep(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1053,12 +1053,12 @@ def unsatZone_forAgri_Ep(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1068,10 +1068,10 @@ def unsatZone_forAgri_Ep(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1104,12 +1104,12 @@ def unsatZone_forAgri_Ep_percD(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k],
         self.Su_t[k] + self.Fa - self.sumax[k],
         0,
@@ -1117,10 +1117,10 @@ def unsatZone_forAgri_Ep_percD(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = ifthenelse(
+    self.Eu1 = pcr.ifthenelse(
         self.Ft_[k] == 1,
-        max((self.PotEvaporation - self.Ei - self.Ea), 0)
-        * min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
+        pcr.max((self.PotEvaporation - self.Ei - self.Ea), 0)
+        * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
         0,
     )  # no transpiration in case of frozen soil. Added on 22 feb 2016
 
@@ -1129,12 +1129,12 @@ def unsatZone_forAgri_Ep_percD(self, k):
     self.Perc1 = self.perc[k] * self.SuN + self.percDeep
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1146,7 +1146,7 @@ def unsatZone_forAgri_Ep_percD(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1154,12 +1154,12 @@ def unsatZone_forAgri_Ep_percD(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1169,10 +1169,10 @@ def unsatZone_forAgri_Ep_percD(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1205,12 +1205,12 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k],
         self.Su_t[k] + self.Fa - self.sumax[k],
         0,
@@ -1218,19 +1218,19 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.drought = ifthenelse(
+    self.drought = pcr.ifthenelse(
         self.SuN < self.LP[k],
         self.TopoId,
-        ifthenelse(
-            pcrand(self.SuN < 0.8, self.drought),
+        pcr.ifthenelse(
+            pcr.pcrand(self.SuN < 0.8, self.drought),
             self.TopoId,
-            boolean(scalar(self.TopoId) * 0),
+            pcr.boolean(pcr.scalar(self.TopoId) * 0),
         ),
     )
-    self.stijg = max(
-        min(
-            scalar(
-                ifthenelse(
+    self.stijg = pcr.max(
+        pcr.min(
+            pcr.scalar(
+                pcr.ifthenelse(
                     self.drought == 1, self.stijg + self.Su_t[k] - self.Su_t2[k], 0
                 )
             ),
@@ -1238,12 +1238,12 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
         ),
         0,
     )
-    #    self.stijg = max(self.Su_t[k] - self.Su_t2[k], 0)
+    #    self.stijg = pcr.max(self.Su_t[k] - self.Su_t2[k], 0)
 
-    self.Eu1 = ifthenelse(
+    self.Eu1 = pcr.ifthenelse(
         self.Ft_[k] == 1,
-        max((self.PotEvaporation - self.Ei - self.Ea), 0)
-        * min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
+        pcr.max((self.PotEvaporation - self.Ei - self.Ea), 0)
+        * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
         0,
     )  # no transpiration in case of frozen soil. Added on 22 feb 2016
 
@@ -1252,12 +1252,12 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
     self.Perc1 = self.perc[k] * self.SuN + self.percDeep
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1269,7 +1269,7 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1277,12 +1277,12 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1292,10 +1292,10 @@ def unsatZone_forAgri_Ep_percDvar(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1327,10 +1327,10 @@ def unsatZone_forAgri_hourlyEp(self, k):
     - Code for ini-file: 25
     """
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k], self.sumax[k], self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax[k],
         self.Su_t[k] + self.Fa - self.sumax[k],
         0,
@@ -1338,10 +1338,10 @@ def unsatZone_forAgri_hourlyEp(self, k):
     self.SuN = self.Su[k] / self.sumax[k]
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = ifthenelse(
+    self.Eu1 = pcr.ifthenelse(
         self.Ft_[k] == 1,
-        max((self.PotEvaporation - self.Ei - self.Ea), 0)
-        * min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
+        pcr.max((self.PotEvaporation - self.Ei - self.Ea), 0)
+        * pcr.min(self.Su[k] / (self.sumax[k] * self.LP[k]), 1),
         0,
     )  # no transpiration in case of frozen soil. Added on 31 mrt 2016
 
@@ -1349,12 +1349,12 @@ def unsatZone_forAgri_hourlyEp(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1366,7 +1366,7 @@ def unsatZone_forAgri_hourlyEp(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1374,12 +1374,12 @@ def unsatZone_forAgri_hourlyEp(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1389,10 +1389,10 @@ def unsatZone_forAgri_hourlyEp(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax[k]), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1423,16 +1423,16 @@ def unsatZone_forAgri_Jarvis_cropG(self, k):
     - inflow is infiltration from agriculture reservoir
     - Code for ini-file: 18
     """
-    self.cropG_scal = pcr2numpy(self.cropG, NaN)
+    self.cropG_scal = pcr.pcr2numpy(self.cropG, np.nan)
     if any(self.cropG_scal == 1):
         self.sumax2 = self.sumax[k]
     else:
         self.sumax2 = self.sumax[k] * self.redsu[k]
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax2, self.sumax2, self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax2, self.Su_t[k] + self.Fa - self.sumax2, 0
     )
     self.SuN = self.Su[k] / self.sumax2
@@ -1447,12 +1447,12 @@ def unsatZone_forAgri_Jarvis_cropG(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1464,7 +1464,7 @@ def unsatZone_forAgri_Jarvis_cropG(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1472,12 +1472,12 @@ def unsatZone_forAgri_Jarvis_cropG(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1487,10 +1487,10 @@ def unsatZone_forAgri_Jarvis_cropG(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1523,24 +1523,24 @@ def unsatZone_forAgri_Ep_cropG(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.cropG_scal = pcr2numpy(self.cropG, NaN)
+    self.cropG_scal = pcr.pcr2numpy(self.cropG, np.nan)
     if any(self.cropG_scal == 1):
         self.sumax2 = self.sumax[k]
     else:
         self.sumax2 = self.sumax[k] * self.redsu[k]
 
-    self.Su[k] = ifthenelse(
+    self.Su[k] = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax2, self.sumax2, self.Su_t[k] + self.Fa
     )
-    self.Quadd = ifthenelse(
+    self.Quadd = pcr.ifthenelse(
         self.Su_t[k] + self.Fa > self.sumax2, self.Su_t[k] + self.Fa - self.sumax2, 0
     )
     self.SuN = self.Su[k] / self.sumax2
     self.SiN = self.Si[k] / self.imax[k]
 
-    self.Eu1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Eu1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Su[k] / (self.sumax2 * self.LP[k]), 1
     )
 
@@ -1548,12 +1548,12 @@ def unsatZone_forAgri_Ep_cropG(self, k):
     self.Perc1 = self.perc[k] * self.SuN
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Qu1 - self.Eu - self.Perc1
 
-    self.Su_diff = ifthenelse(self.Su[k] < 0, self.Su[k], 0)
+    self.Su_diff = pcr.ifthenelse(self.Su[k] < 0, self.Su[k], 0)
     self.Eu = (
         self.Eu1
         + (
             self.Eu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1565,7 +1565,7 @@ def unsatZone_forAgri_Ep_cropG(self, k):
         self.Qu1
         + (
             self.Qu1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1573,12 +1573,12 @@ def unsatZone_forAgri_Ep_cropG(self, k):
         )
         * self.Su_diff
     )
-    self.Perc = ifthenelse(
+    self.Perc = pcr.ifthenelse(
         self.Perc1 > 0,
         self.Perc1
         + (
             self.Perc1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qu1 + self.Eu1 + self.Perc1 > 0,
                 self.Qu1 + self.Eu1 + self.Perc1,
                 1,
@@ -1588,10 +1588,10 @@ def unsatZone_forAgri_Ep_cropG(self, k):
         self.Perc1,
     )
     self.Su[k] = self.Su_t[k] + (self.Fa - self.Quadd) - self.Eu - self.Qu - self.Perc
-    self.Su[k] = ifthenelse(self.Su[k] < 0, 0, self.Su[k])
-    self.Su_diff2 = ifthen(self.Su[k] < 0, self.Su[k])
+    self.Su[k] = pcr.ifthenelse(self.Su[k] < 0, 0, self.Su[k])
+    self.Su_diff2 = pcr.ifthen(self.Su[k] < 0, self.Su[k])
 
-    self.Cap = min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
+    self.Cap = pcr.min(self.cap[k] * (1 - self.Su[k] / self.sumax2), self.Ss)
     self.Su[k] = self.Su[k] + self.Cap
 
     self.wbSu_[k] = (
@@ -1620,17 +1620,17 @@ def unsatZone_withAgri(self, k):
     - Qu is determined with a beta function (same as in HBV?)
     - Code for ini-file: 10
     """
-    self.Sa[k] = ifthenelse(
+    self.Sa[k] = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k], self.samax[k], self.Sa_t[k] + self.Pe
     )
-    self.Qaadd = ifthenelse(
+    self.Qaadd = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k],
         self.Sa_t[k] + self.Pe - self.samax[k],
         0,
     )
     self.SaN = self.Sa[k] / self.samax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax[k] * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
@@ -1638,12 +1638,12 @@ def unsatZone_withAgri(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Ea1 - self.Fa1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Ea = (
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
@@ -1653,18 +1653,18 @@ def unsatZone_withAgri(self, k):
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
         * self.Sa_diff
     )
-    self.Fa = ifthenelse(
+    self.Fa = pcr.ifthenelse(
         self.Fa1 > 0,
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
@@ -1672,10 +1672,10 @@ def unsatZone_withAgri(self, k):
         self.Fa1,
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Qa - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
-    self.Capa = min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
+    self.Capa = pcr.min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
     self.Sa[k] = self.Sa[k] + self.Capa
 
     self.Su[k] = self.Su_t[k] + self.Fa - self.Capa
@@ -1718,19 +1718,19 @@ def unsatZone_withAgri_Ep(self, k):
     """
 
     JarvisCoefficients.calcEp(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour >= 0, self.EpHour, 0), 0)
 
-    self.Sa[k] = ifthenelse(
+    self.Sa[k] = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k], self.samax[k], self.Sa_t[k] + self.Pe
     )
-    self.Qaadd = ifthenelse(
+    self.Qaadd = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k],
         self.Sa_t[k] + self.Pe - self.samax[k],
         0,
     )
     self.SaN = self.Sa[k] / self.samax[k]
 
-    self.Ea1 = max((self.PotEvaporation - self.Ei), 0) * min(
+    self.Ea1 = pcr.max((self.PotEvaporation - self.Ei), 0) * pcr.min(
         self.Sa[k] / (self.samax[k] * self.LP[k]), 1
     )
     self.Qa1 = (self.Pe - self.Qaadd) * (1 - (1 - self.SaN) ** self.beta[k])
@@ -1738,12 +1738,12 @@ def unsatZone_withAgri_Ep(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Ea1 - self.Fa1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Ea = (
         self.Ea1
         + (
             self.Ea1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
@@ -1753,18 +1753,18 @@ def unsatZone_withAgri_Ep(self, k):
         self.Qa1
         + (
             self.Qa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
         * self.Sa_diff
     )
-    self.Fa = ifthenelse(
+    self.Fa = pcr.ifthenelse(
         self.Fa1 > 0,
         self.Fa1
         + (
             self.Fa1
-            / ifthenelse(
+            / pcr.ifthenelse(
                 self.Qa1 + self.Ea1 + self.Fa1 > 0, self.Qa1 + self.Ea1 + self.Fa1, 1
             )
         )
@@ -1772,10 +1772,10 @@ def unsatZone_withAgri_Ep(self, k):
         self.Fa1,
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Qa - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
-    self.Capa = min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
+    self.Capa = pcr.min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
     self.Sa[k] = self.Sa[k] + self.Capa
 
     self.Su[k] = self.Su_t[k] + self.Fa - self.Capa
@@ -1817,10 +1817,10 @@ def unsatZone_withAgri_Jarvis(self, k):
     - Code for ini-file: 15
     """
 
-    self.Sa[k] = ifthenelse(
+    self.Sa[k] = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k], self.samax[k], self.Sa_t[k] + self.Pe
     )
-    self.Qaadd = ifthenelse(
+    self.Qaadd = pcr.ifthenelse(
         self.Sa_t[k] + self.Pe > self.samax[k],
         self.Sa_t[k] + self.Pe - self.samax[k],
         0,
@@ -1837,24 +1837,24 @@ def unsatZone_withAgri_Jarvis(self, k):
 
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Qa1 - self.Ea - self.Fa1
 
-    self.Sa_diff = ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
+    self.Sa_diff = pcr.ifthenelse(self.Sa[k] < 0, self.Sa[k], 0)
     self.Qa = (
         self.Qa1
-        + (self.Qa1 / ifthenelse(self.Qa1 + self.Fa1 > 0, self.Qa1 + self.Fa1, 1))
+        + (self.Qa1 / pcr.ifthenelse(self.Qa1 + self.Fa1 > 0, self.Qa1 + self.Fa1, 1))
         * self.Sa_diff
     )
-    self.Fa = ifthenelse(
+    self.Fa = pcr.ifthenelse(
         self.Fa1 > 0,
         self.Fa1
-        + (self.Fa1 / ifthenelse(self.Qa1 + self.Fa1 > 0, self.Qa1 + self.Fa1, 1))
+        + (self.Fa1 / pcr.ifthenelse(self.Qa1 + self.Fa1 > 0, self.Qa1 + self.Fa1, 1))
         * self.Sa_diff,
         self.Fa1,
     )
     self.Sa[k] = self.Sa_t[k] + (self.Pe - self.Qaadd) - self.Ea - self.Qa - self.Fa
-    self.Sa[k] = ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
-    self.Sa_diff2 = ifthen(self.Sa[k] < 0, self.Sa[k])
+    self.Sa[k] = pcr.ifthenelse(self.Sa[k] < 0, 0, self.Sa[k])
+    self.Sa_diff2 = pcr.ifthen(self.Sa[k] < 0, self.Sa[k])
 
-    self.Capa = min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
+    self.Capa = pcr.min(self.cap[k] * (1 - self.Sa[k] / self.samax[k]), self.Su[k])
     self.Sa[k] = self.Sa[k] + self.Capa
 
     self.Su[k] = self.Su_t[k] + self.Fa - self.Capa

--- a/wflow/reservoir_Sw.py
+++ b/wflow/reservoir_Sw.py
@@ -44,9 +44,9 @@ def snow_no_reservoir(self, k):
     except:
         JarvisCoefficients.calcEpSnowHour(self, k)
     self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
-    self.Qw_[k] = max(self.PrecipitationSnow, 0)
+    self.Qw_[k] = pcr.max(self.PrecipitationSnow, 0)
     self.Ew_[k] = 0.0
     self.Sw[k] = 0.0
     self.wbSw_[k] = (
@@ -62,29 +62,29 @@ def snow(self, k):
     """
     JarvisCoefficients.calcEpSnow(self, k)
     self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = max(self.Fm[k] * (self.Temperature - self.Tm[k]), 0)
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Qw1 = pcr.max(self.Fm[k] * (self.Temperature - self.Tm[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -104,30 +104,30 @@ def snow_rain(self, k):
 
     JarvisCoefficients.calcEpSnow(self, k)
     # self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Fm2 = max(self.Fm[k] * self.Precipitation, self.Fm[k])
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = max(min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
+    self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -146,30 +146,30 @@ def snow_rain_hourlyEp(self, k):
     """
 
     JarvisCoefficients.calcEpSnowHour(self, k)
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Fm2 = max(self.Fm[k] * self.Precipitation, self.Fm[k])
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = max(min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
+    self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -189,30 +189,30 @@ def snow_rain_Tsurf(self, k):
 
     JarvisCoefficients.calcEpSnow(self, k)
     # self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Fm2 = max(self.Fm[k] * self.Precipitation, self.Fm[k])
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = max(min(self.Fm2 * (self.TempSurf - self.Tm[k]), self.Sw[k]), 0)
+    self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.TempSurf - self.Tm[k]), self.Sw[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -231,31 +231,31 @@ def snow_rain_TsurfAir(self, k):
     """
     JarvisCoefficients.calcEpSnow(self, k)
     # self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
     self.Temp = (self.TempSurf + self.Temperature) / 2
 
-    self.Fm2 = max(self.Fm[k] * self.Precipitation, self.Fm[k])
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = max(min(self.Fm2 * (self.Temp - self.Tm[k]), self.Sw[k]), 0)
+    self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.Temp - self.Tm[k]), self.Sw[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -274,30 +274,30 @@ def snow_rain_Tsurf_noEw(self, k):
     """
     JarvisCoefficients.calcEpSnow(self, k)
     # self.PotEvaporation = self.EpHour
-    self.PotEvaporation = cover(ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
+    self.PotEvaporation = pcr.cover(pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Fm2 = max(self.Fm[k] * self.Precipitation, self.Fm[k])
+    self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
     self.Ew1 = 0
-    self.Qw1 = max(min(self.Fm2 * (self.TempSurf - self.Tm[k]), self.Sw[k]), 0)
+    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.TempSurf - self.Tm[k]), self.Sw[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -315,32 +315,32 @@ def snowHour(self, k):
     """
     #    JarvisCoefficients.calcEpSnowHour(self,k)
     #    self.PotEvaporation = self.EpHour
-    #    self.PotEvaporation = ifthenelse(self.EpHour > 0, self.EpHour, 0)
+    #    self.PotEvaporation = pcr.ifthenelse(self.EpHour > 0, self.EpHour, 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow
 
-    self.Ew1 = max(min(self.PotEvaporation, self.Sw[k]), 0)
+    self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
     #    self.Ew1 = 0
-    self.Qw1 = max(self.Fm[k] * (self.Temperature - self.Tm[k]), 0)
+    self.Qw1 = pcr.max(self.Fm[k] * (self.Temperature - self.Tm[k]), 0)
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
-    self.Sw_diff = ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
+    self.Sw_diff = pcr.ifthenelse(self.Sw[k] < 0, self.Sw[k], 0)
     self.Ew = (
         self.Ew1
-        + (self.Ew1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Ew1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Qw = (
         self.Qw1
-        + (self.Qw1 / ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
+        + (self.Qw1 / pcr.ifthenelse(self.Ew1 + self.Qw1 > 0, self.Ew1 + self.Qw1, 1))
         * self.Sw_diff
     )
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew - self.Qw
-    self.Sw[k] = ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
-    self.Sw_diff2 = ifthen(self.Sw[k] < 0, self.Sw[k])
+    self.Sw[k] = pcr.ifthenelse(self.Sw[k] < 0, 0, self.Sw[k])
+    self.Sw_diff2 = pcr.ifthen(self.Sw[k] < 0, self.Sw[k])
 
-    #    if any(pcr2numpy(self.Sw[k],nan) > 0):
+    #    if any(pcr.pcr2numpy(self.Sw[k],np.nan) > 0):
     #        pdb.set_trace()
     self.wbSw_[k] = (
         self.PrecipitationSnow - self.Ew - self.Qw - self.Sw[k] + self.Sw_t[k]
@@ -350,5 +350,5 @@ def snowHour(self, k):
     self.Qw_[k] = self.Qw
 
 
-#    if any(pcr2numpy(self.Qw,nan) > 0):
+#    if any(pcr.pcr2numpy(self.Qw,np.nan) > 0):
 #        pdb.set_trace()

--- a/wflow/reservoir_Sw.py
+++ b/wflow/reservoir_Sw.py
@@ -110,7 +110,9 @@ def snow_rain(self, k):
 
     self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
     self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
+    self.Qw1 = pcr.max(
+        pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0
+    )
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 
@@ -152,7 +154,9 @@ def snow_rain_hourlyEp(self, k):
 
     self.Fm2 = pcr.max(self.Fm[k] * self.Precipitation, self.Fm[k])
     self.Ew1 = pcr.max(pcr.min(self.PotEvaporation, self.Sw[k]), 0)
-    self.Qw1 = pcr.max(pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0)
+    self.Qw1 = pcr.max(
+        pcr.min(self.Fm2 * (self.Temperature - self.Tm[k]), self.Sw[k]), 0
+    )
 
     self.Sw[k] = self.Sw_t[k] + self.PrecipitationSnow - self.Ew1 - self.Qw1
 

--- a/wflow/stats.py
+++ b/wflow/stats.py
@@ -486,7 +486,9 @@ def get_number_of_sign_changes(Avalues, Bvalues, N="", NoData=NoDataVal):
             Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             if Avalues[i] != Bvalues[i]:
-                curr_sign = (Avalues[i] - Bvalues[i]) / math.fabs(Avalues[i] - Bvalues[i])
+                curr_sign = (Avalues[i] - Bvalues[i]) / math.fabs(
+                    Avalues[i] - Bvalues[i]
+                )
             else:
                 curr_sign = sign
             if curr_sign != sign:

--- a/wflow/stats.py
+++ b/wflow/stats.py
@@ -38,9 +38,9 @@
 #
 
 
-# Import math library
-from math import sqrt
 from math import fabs
+from math import sqrt
+
 from numpy import isnan
 
 NoDataVal = -999

--- a/wflow/stats.py
+++ b/wflow/stats.py
@@ -63,7 +63,7 @@ def get_mean(values, N="", NoData=NoDataVal, Skip=""):
     Nact = 0
     Nskip = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             if Skip and values[i] == Skip:
                 Nskip = Nskip + 1
             else:
@@ -86,7 +86,7 @@ def get_median(values, N="", NoData=NoDataVal):
     new_value = []
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             new_value = new_value + [values[i]]
             Nact = Nact + 1
     if Nact > 0:
@@ -113,7 +113,7 @@ def get_var(values, N="", mean="", NoData=NoDataVal):
     var = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             var = var + (values[i] - mean) * (values[i] - mean)
             Nact = Nact + 1
     if Nact > 1:
@@ -137,12 +137,12 @@ def get_stdev(values, N="", mean="", NoData=NoDataVal):
     stdev = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             stdev = stdev + (values[i] - mean) * (values[i] - mean)
             Nact = Nact + 1
     if Nact > 1:
         stdev = stdev / (Nact - 1)
-        stdev = sqrt(stdev)
+        stdev = math.sqrt(stdev)
     else:
         stdev = NoData
     return (stdev, Nact)
@@ -164,7 +164,7 @@ def get_skew(values, N="", mean="", stdev="", NoData=NoDataVal):
     skew = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             skew = skew + (values[i] - mean) ** 3
             Nact = Nact + 1
     if (stdev ** 3 * (Nact - 1) * (Nact - 2)) != 0:
@@ -184,7 +184,7 @@ def get_sum(values, N="", NoData=NoDataVal):
     sum = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             sum = sum + values[i]
             Nact = Nact + 1
     if Nact == 0:
@@ -208,7 +208,7 @@ def get_min(values, N="", NoData=NoDataVal):
         min = values[pos]
         minpos = pos
         for i in range(pos, N):
-            if values[i] != NoData and not isnan(values[i]):
+            if values[i] != NoData and not np.isnan(values[i]):
                 if values[i] < min:
                     min = values[i]
                     minpos = i
@@ -238,7 +238,7 @@ def get_max(values, N="", NoData=NoDataVal):
         maxpos = 0
         Nact = 0
         for i in range(pos, N):
-            if values[i] != NoData and not isnan(values[i]):
+            if values[i] != NoData and not np.isnan(values[i]):
                 if values[i] > max:
                     max = values[i]
                     maxpos = i
@@ -262,7 +262,7 @@ def get_count_over_threshold(values, threshold, N="", NoData=NoDataVal):
     count = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             if values[i] >= threshold:
                 count = count + 1
             Nact = Nact + 1
@@ -344,8 +344,8 @@ def get_bias(Avalues, Bvalues, N="", NoData=NoDataVal):
     bias = 0
     Nact = 0
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             bias = bias + (Avalues[i] - Bvalues[i])
             Nact = Nact + 1
@@ -367,15 +367,15 @@ def get_root_mean_square(Avalues, Bvalues, N="", NoData=NoDataVal):
     rmse = 0
     Nact = 0
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             rmse = rmse + (Avalues[i] - Bvalues[i]) * (Avalues[i] - Bvalues[i])
             Nact = Nact + 1
     if Nact == 0:
         rmse = NoData
     else:
-        rmse = sqrt(rmse / Nact)
+        rmse = math.sqrt(rmse / Nact)
     return (rmse, Nact)
 
 
@@ -390,15 +390,15 @@ def get_mean_absolute_error(Avalues, Bvalues, N="", NoData=NoDataVal):
     abserr = 0
     Nact = 0
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
-            abserr = abserr + fabs(Avalues[i] - Bvalues[i])
+            abserr = abserr + math.fabs(Avalues[i] - Bvalues[i])
             Nact = Nact + 1
     if Nact == 0:
         abserr = NoData
     else:
-        abserr = sqrt(abserr / Nact)
+        abserr = math.sqrt(abserr / Nact)
     return (abserr, Nact)
 
 
@@ -413,8 +413,8 @@ def get_max_absolute_error(Avalues, Bvalues, N="", NoData=NoDataVal):
     absmax = []
     Nact = 0
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             absmax = absmax + [fabs(Avalues[i] - Bvalues[i])]
             Nact = Nact + 1
@@ -438,8 +438,8 @@ def get_nash_sutcliffe(Avalues, Bvalues, N="", NoData=NoDataVal):
     Nact = 0
     mean_val = get_mean(Avalues, NoData=NoData)[0]
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             num = num + (Avalues[i] - Bvalues[i]) * (Avalues[i] - Bvalues[i])
             denom = denom + (Avalues[i] - mean_val) * (Avalues[i] - mean_val)
@@ -464,7 +464,7 @@ def get_peak_diff(Avalues, Bvalues, N="", NoData=NoDataVal):
         return (NoData, Nact)
     else:
         Nact = (Aact + Bact) / 2
-        return (fabs(max_A - max_B), Nact)
+        return (math.fabs(max_A - max_B), Nact)
 
 
 def get_number_of_sign_changes(Avalues, Bvalues, N="", NoData=NoDataVal):
@@ -476,17 +476,17 @@ def get_number_of_sign_changes(Avalues, Bvalues, N="", NoData=NoDataVal):
     if not N:
         N = len(Avalues)
     if Avalues[0] != Bvalues[0]:
-        sign = (Avalues[0] - Bvalues[0]) / fabs(Avalues[0] - Bvalues[0])
+        sign = (Avalues[0] - Bvalues[0]) / math.fabs(Avalues[0] - Bvalues[0])
     else:
         sign = 1
     NSC = 0
     Nact = 0
     for i in range(N):
-        if (Avalues[i] != NoData and not isnan(Avalues[i])) and (
-            Bvalues[i] != NoData and not isnan(Avalues[i])
+        if (Avalues[i] != NoData and not np.isnan(Avalues[i])) and (
+            Bvalues[i] != NoData and not np.isnan(Avalues[i])
         ):
             if Avalues[i] != Bvalues[i]:
-                curr_sign = (Avalues[i] - Bvalues[i]) / fabs(Avalues[i] - Bvalues[i])
+                curr_sign = (Avalues[i] - Bvalues[i]) / math.fabs(Avalues[i] - Bvalues[i])
             else:
                 curr_sign = sign
             if curr_sign != sign:
@@ -512,7 +512,7 @@ def get_peak_threshold_diff(Avalues, Bvalues, threshold, N="", NoData=NoDataVal)
     if Aact == 0 or Bact == 0:
         return (NoData, 0)
     else:
-        return (fabs(Apeaks - Bpeaks), (Aact + Bact) / 2)
+        return (math.fabs(Apeaks - Bpeaks), (Aact + Bact) / 2)
 
 
 def get_covariance(Avalues, Bvalues, N="", NoData=NoDataVal):
@@ -633,7 +633,7 @@ def filter_threshold(values, threshold, FILTER="ABOVE", N="", NoData=NoDataVal):
     Npeaks = 0
     Nact = 0
     for i in range(N):
-        if values[i] != NoData and not isnan(values[i]):
+        if values[i] != NoData and not np.isnan(values[i]):
             if FILTER == "ABOVE":
                 if values[i] >= threshold:
                     Npeaks = Npeaks + 1

--- a/wflow/testrunner_wflowhbv.py
+++ b/wflow/testrunner_wflowhbv.py
@@ -82,7 +82,7 @@ def main():
         # dynModelFw.wf_setValue("ForecQ_qmec", -1.0 * inflowQ  ,6.46823,51.6821)
         Resoutflow = inflowQ
         dynModelFw.wf_setValue("ForecQ_qmec", Resoutflow, 6.43643, 51.7226)
-        dynModelFw.wf_setValues("P", scalar(ts) * 0.1)
+        dynModelFw.wf_setValues("P", pcr.scalar(ts) * 0.1)
         # dynModelFw.wf_setValue("ForecQ_qmec",inflowQ * 1000 ,6.47592,51.7288)
         # update runoff ONLY NEEDED IF YOU FIDDLE WITH THE KIN_WAVE RESERVOIR
         myModel.updateRunOff()

--- a/wflow/wf_DynamicFramework.py
+++ b/wflow/wf_DynamicFramework.py
@@ -12,29 +12,20 @@ and interrogate the model.
 # TODO: Remove command-line options from models such as -F that is now in the ini
 # TODO: Fix timestep not forewarding in BMI runs (for reading writing maps)
 
+import calendar
 import configparser
-
-from wflow.wf_netcdfio import *
-from . import pcrut
+import datetime
 import glob
 import traceback
-from . import wflow_adapt
 from collections import namedtuple
-
-import logging
-
-import pcraster
-from pcraster.framework import *
-from .wflow_lib import *
-import time
-import calendar
-import datetime
-
-from wflow import __version__
 from functools import reduce
 
-# from wflow import __release__
-# from wflow import __build__
+from wflow import __version__
+from wflow.wf_netcdfio import *
+
+from . import pcrut
+from . import wflow_adapt
+from .wflow_lib import *
 
 
 def log_uncaught_exceptions(ex_cls, ex, tb):

--- a/wflow/wf_DynamicFramework.py
+++ b/wflow/wf_DynamicFramework.py
@@ -596,7 +596,9 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
 
         self._update_time_from_DT()
 
-        self.TheClone = pcr.scalar(pcr.xcoordinate((pcr.spatial(pcr.boolean(1.0))))) * 0.0
+        self.TheClone = (
+            pcr.scalar(pcr.xcoordinate((pcr.spatial(pcr.boolean(1.0))))) * 0.0
+        )
 
     def _update_time_from_DT(self):
         """
@@ -927,7 +929,9 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
             cmask = self._userModel().TopoId
 
             cmask = pcr.ifthen(cmask > 0, cmask)
-            totalzeromap = pcr.pcr2numpy(pcr.maptotal(pcr.scalar(pcr.defined(cmask))), 0)
+            totalzeromap = pcr.pcr2numpy(
+                pcr.maptotal(pcr.scalar(pcr.defined(cmask))), 0
+            )
             resttotal = pcr.pcr2numpy(pcr.maptotal(pcr.scalar(pcr.defined(rest))), 0)
 
             if resttotal[0, 0] < totalzeromap[0, 0]:
@@ -986,7 +990,9 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
             rest = pcr.cover(pcr.readmap(mapname), default)
         else:
             if os.path.isfile(pathtotbl):
-                rest = pcr.lookupscalar(pathtotbl, landuse, subcatch, soil, pcr.cover(0.0) + n)
+                rest = pcr.lookupscalar(
+                    pathtotbl, landuse, subcatch, soil, pcr.cover(0.0) + n
+                )
                 self.logger.info("Creating map from table: " + pathtotbl)
             else:
                 self.logger.warning(
@@ -1000,7 +1006,9 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
             cmask = self._userModel().TopoId
 
             cmask = pcr.ifthen(cmask > 0, cmask)
-            totalzeromap = pcr.pcr2numpy(pcr.maptotal(pcr.scalar(pcr.defined(cmask))), 0)
+            totalzeromap = pcr.pcr2numpy(
+                pcr.maptotal(pcr.scalar(pcr.defined(cmask))), 0
+            )
             resttotal = pcr.pcr2numpy(pcr.maptotal(pcr.scalar(pcr.defined(rest))), 0)
 
             if resttotal[0, 0] < totalzeromap[0, 0]:
@@ -2003,7 +2011,13 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
                     nr = nr + 1
                 else:
                     if nr > 0:
-                        self.logger.info("state variable " + str(var) + " contains " + str(nr) + " state files (stack)")
+                        self.logger.info(
+                            "state variable "
+                            + str(var)
+                            + " contains "
+                            + str(nr)
+                            + " state files (stack)"
+                        )
                     stop = 1
 
             if nr == 0:
@@ -2998,7 +3012,9 @@ class wf_DynamicFramework(pcraster.framework.frameworkBase.FrameworkBase):
 
         if hasattr(self._userModel(), "_inDynamic"):
             if self._userModel()._inDynamic() or self._inUpdateWeight():
-                newName = pcraster.framework.generateNameT(name, self._userModel().currentTimeStep())
+                newName = pcraster.framework.generateNameT(
+                    name, self._userModel().currentTimeStep()
+                )
 
         if newName == "":  # For files from suspend
             newName = name

--- a/wflow/wf_netcdfio.py
+++ b/wflow/wf_netcdfio.py
@@ -9,18 +9,16 @@ $Id: wf_DynamicFramework.py 915 2014-02-10 07:33:56Z schelle $
 $Rev: 915 $
 """
 
+import datetime as dt
+
+import cftime
+import netCDF4
 import osgeo
 import osgeo.ogr
-import netCDF4
-import cftime
 import pyproj
-import os
-
-from pcraster import *
-from numpy import *
-import time
-import datetime as dt
 import wflow.pcrut as _pcrut
+from numpy import *
+from pcraster import *
 
 globmetadata = {}
 globmetadata["title"] = "wflow output mapstack"

--- a/wflow/wf_netcdfio.py
+++ b/wflow/wf_netcdfio.py
@@ -257,12 +257,8 @@ class netcdfoutput:
         cellsize = pcr.clone().cellSize()
         yupper = pcr.clone().north()
         xupper = pcr.clone().west()
-        x = pcr.pcr2numpy(
-            pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[0, :]
-        y = pcr.pcr2numpy(
-            pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[:, 0]
+        x = pcr.pcr2numpy(pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[0, :]
+        y = pcr.pcr2numpy(pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[:, 0]
 
         # Shift one timestep as we output at the end
         # starttime = starttime + dt.timedelta(seconds=timestepsecs)
@@ -443,12 +439,8 @@ class netcdfoutputstatic:
         cellsize = pcr.clone().cellSize()
         yupper = pcr.clone().north()
         xupper = pcr.clone().west()
-        x = pcr.pcr2numpy(
-            pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[0, :]
-        y = pcr.pcr2numpy(
-            pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[:, 0]
+        x = pcr.pcr2numpy(pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[0, :]
+        y = pcr.pcr2numpy(pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[:, 0]
 
         # Shift one timestep as we output at the end
         # starttime = starttime + dt.timedelta(seconds=timestepsecs)
@@ -602,7 +594,9 @@ class netcdfinput:
         maxmb = 40
 
         self.maxlentime = len(self.dataset.variables["time"])
-        self.maxsteps = np.minimum(maxmb * len(a) / floatspermb + 1, self.maxlentime - 1)
+        self.maxsteps = np.minimum(
+            maxmb * len(a) / floatspermb + 1, self.maxlentime - 1
+        )
         self.fstep = 0
         self.lstep = self.fstep + self.maxsteps
         self.offset = 0
@@ -643,12 +637,8 @@ class netcdfinput:
             else:
                 self.flip = True
 
-        x = pcr.pcr2numpy(
-            pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[0, :]
-        y = pcr.pcr2numpy(
-            pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[:, 0]
+        x = pcr.pcr2numpy(pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[0, :]
+        y = pcr.pcr2numpy(pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[:, 0]
 
         # Get average cell size
         acc = (
@@ -865,12 +855,8 @@ class netcdfinputstates:
             else:
                 self.flip = True
 
-        x = pcr.pcr2numpy(
-            pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[0, :]
-        y = pcr.pcr2numpy(
-            pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[:, 0]
+        x = pcr.pcr2numpy(pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[0, :]
+        y = pcr.pcr2numpy(pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[:, 0]
 
         # Get average cell size
         acc = (
@@ -1000,12 +986,8 @@ class netcdfinputstatic:
         except:
             self.y = self.dataset.variables["lat"][:]
 
-        x = pcr.pcr2numpy(
-            pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[0, :]
-        y = pcr.pcr2numpy(
-            pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan
-        )[:, 0]
+        x = pcr.pcr2numpy(pcr.xcoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[0, :]
+        y = pcr.pcr2numpy(pcr.ycoordinate(pcr.boolean(pcr.cover(1.0))), np.nan)[:, 0]
 
         (self.latidx,) = np.logical_and(self.x >= x.min(), self.x < x.max()).nonzero()
         (self.lonidx,) = np.logical_and(self.y >= x.min(), self.y < y.max()).nonzero()

--- a/wflow/wflow_adapt.py
+++ b/wflow/wflow_adapt.py
@@ -49,22 +49,19 @@ $Rev: 915 $
      
 """
 
-import getopt, sys, os
-
-from xml.etree.ElementTree import *
-
-from datetime import *
-
-import shutil
-from glob import *
+import configparser
+import getopt
 import logging
 import logging.handlers
-import configparser
+import os
+import shutil
+import sys
+from datetime import *
+from xml.etree.ElementTree import *
+
 import numpy
-
-import wflow.wflow_lib as wflow_lib
 import wflow.pcrut as pcrut
-
+import wflow.wflow_lib as wflow_lib
 
 outMaps = ["run.xml", "lev.xml"]
 iniFile = "wflow_sbm.ini"

--- a/wflow/wflow_adapt.py
+++ b/wflow/wflow_adapt.py
@@ -339,7 +339,7 @@ def tss_topixml(tssfile, xmlfile, locationname, parametername, Sdate, timestep):
         dumm[:] = -999.0
         tss = numpy.vstack((dumm, tss))
 
-    # replace NaN with missing values
+    # replace np.nan with missing values
     tss[numpy.isnan(tss)] = missval
 
     trange = timedelta(seconds=timestep * (tss.shape[0]))

--- a/wflow/wflow_bmi.py
+++ b/wflow/wflow_bmi.py
@@ -1,25 +1,22 @@
 __author__ = "schelle"
 
-import os
-import logging
+import configparser
 import datetime
+import logging
 
-import wflow.bmi as bmi
 import numpy as np
-from wflow.pcrut import setlogger
-
-# wflow models we want to support, keep up to date with wflow_model
-import wflow.wflow_sbm
-import wflow.wflow_hbv
-import wflow.wflow_routing
+import wflow.bmi as bmi
 import wflow.wflow_floodmap
+import wflow.wflow_hbv
 import wflow.wflow_lintul
+import wflow.wflow_routing
+import wflow.wflow_sbm
 import wflow.wflow_sceleton
 import wflow.wflow_w3ra
-
 from pcraster import *
-import configparser
+from wflow.pcrut import setlogger
 
+# wflow models we want to support
 wflow_models = [
     wflow.wflow_sbm,
     wflow.wflow_hbv,

--- a/wflow/wflow_bmi.py
+++ b/wflow/wflow_bmi.py
@@ -3,6 +3,7 @@ __author__ = "schelle"
 import configparser
 import datetime
 import logging
+import os
 
 import numpy as np
 import wflow.bmi as bmi
@@ -13,7 +14,7 @@ import wflow.wflow_routing
 import wflow.wflow_sbm
 import wflow.wflow_sceleton
 import wflow.wflow_w3ra
-from pcraster import *
+import pcraster as pcr
 from wflow.pcrut import setlogger
 
 # wflow models we want to support
@@ -422,9 +423,9 @@ class wflowbmi_light(object):
 
         if self.wrtodisk:
             fname = str(self.currenttimestep) + "_get_" + long_var_name + ".map"
-            arpcr = numpy2pcr(Scalar, src, -999)
+            arpcr = pcr.numpy2pcr(pcr.Scalar, src, -999)
             self.bmilogger.debug("Writing to disk: " + fname)
-            report(arpcr, fname)
+            pcr.report(arpcr, fname)
 
         return src
 
@@ -439,9 +440,9 @@ class wflowbmi_light(object):
 
         if self.wrtodisk:
             fname = str(self.currenttimestep) + "_set_" + long_var_name + ".map"
-            arpcr = numpy2pcr(Scalar, src, -999)
+            arpcr = pcr.numpy2pcr(pcr.Scalar, src, -999)
             self.bmilogger.debug("Writing to disk: " + fname)
-            report(arpcr, fname)
+            pcr.report(arpcr, fname)
 
         if long_var_name in self.outputonlyvars:
             self.bmilogger.error(
@@ -1082,9 +1083,9 @@ class wflowbmi_csdms(bmi.Bmi):
 
             if self.wrtodisk:
                 fname = str(self.currenttimestep) + "_get_" + long_var_name + ".map"
-                arpcr = numpy2pcr(Scalar, ret, -999)
+                arpcr = pcr.numpy2pcr(pcr.Scalar, ret, -999)
                 self.bmilogger.debug("Writing to disk: " + fname)
-                report(arpcr, fname)
+                pcr.report(arpcr, fname)
 
             return ret
         else:
@@ -1291,9 +1292,9 @@ class wflowbmi_csdms(bmi.Bmi):
         self.bmilogger.debug("set_value: " + long_var_name + ":" + str(src))
         if self.wrtodisk:
             fname = str(self.currenttimestep) + "_set_" + long_var_name + ".map"
-            arpcr = numpy2pcr(Scalar, src, -999)
+            arpcr = pcr.numpy2pcr(pcr.Scalar, src, -999)
             self.bmilogger.debug("Writing to disk: " + fname)
-            report(arpcr, fname)
+            pcr.report(arpcr, fname)
 
         if long_var_name in self.outputonlyvars:
             self.bmilogger.error(

--- a/wflow/wflow_bmi_combined.py
+++ b/wflow/wflow_bmi_combined.py
@@ -1,11 +1,12 @@
 import configparser
 import json
 import logging
+import os
 
 import numpy as np
 import wflow.bmi
 import wflow.wflow_bmi as wfbmi
-from pcraster import *
+import pcraster as pcr
 from wflow.pcrut import setlogger
 
 
@@ -143,8 +144,8 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
                     else:
                         ind = [list(ind_temp[0]), list(ind_temp[1])]
                 elif exchange_from[2].endswith("map"):
-                    map_temp = readmap(mappingdir + exchange_from[2])
-                    map_flip = np.flipud(pcr2numpy(map_temp, 0))
+                    map_temp = pcr.readmap(mappingdir + exchange_from[2])
+                    map_flip = np.flipud(pcr.pcr2numpy(map_temp, 0))
                     ind_temp = np.where(map_flip == 1)
                     ind = [list(ind_temp[0]), list(ind_temp[1])]
                 self.indices_from.append(ind)
@@ -165,8 +166,8 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
                     else:
                         ind = [list(ind_temp[0]), list(ind_temp[1])]
                 elif exchange_to[2].endswith("map"):
-                    map_temp = readmap(mappingdir + exchange_to[2])
-                    map_flip = np.flipud(pcr2numpy(map_temp, 0))
+                    map_temp = pcr.readmap(mappingdir + exchange_to[2])
+                    map_flip = np.flipud(pcr.pcr2numpy(map_temp, 0))
                     ind_temp = np.where(map_flip == 1)
                     ind = [list(ind_temp[0]), list(ind_temp[1])]
                 self.indices_to.append(ind)
@@ -559,7 +560,7 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_start_time())
 
-        return numpy.array(st).max()
+        return np.array(st).max()
 
     def get_current_time(self):
         """
@@ -585,7 +586,7 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_end_time())
 
-        return numpy.array(st).min()
+        return np.array(st).min()
 
     def get_time_step(self):
         """
@@ -597,7 +598,7 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_time_step())
 
-        return max(st)[0]
+        return max(st)
 
     def get_time_units(self):
         """
@@ -625,8 +626,8 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         if cname[0] in self.bmimodels:
             tmp = self.bmimodels[cname[0]].get_value(cname[1])
             if self.wrtodisk:
-                report(
-                    numpy2pcr(Scalar, tmp, -999),
+                pcr.report(
+                    pcr.numpy2pcr(pcr.Scalar, tmp, -999),
                     long_var_name + "_get_" + str(self.get_current_time()) + ".map",
                 )
             return tmp
@@ -648,8 +649,8 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         if cname[0] in self.bmimodels:
             tmp = self.bmimodels[cname[0]].get_value(cname[1])
             if self.wrtodisk:
-                report(
-                    numpy2pcr(Scalar, tmp, -999),
+                pcr.report(
+                    pcr.numpy2pcr(pcr.Scalar, tmp, -999),
                     long_var_name + "_get_" + str(self.get_current_time()) + ".map",
                 )
             return self.bmimodels[cname[0]].get_value_at_indices(cname[1], inds)
@@ -672,7 +673,7 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
             self.bmimodels[cname[0]].set_value_at_indices(cname[1], inds, src)
             if self.wrtodisk:
                 npmap = self.bmimodels[cname[0]].getnumpy(cname[1], inds, src)
-                report(
+                pcr.report(
                     self.bmimodels[cname[0]].get_value(cname[1]),
                     long_var_name + "_set_" + str(self.get_current_time()) + ".map",
                 )
@@ -816,8 +817,8 @@ class wflowbmi_csdms(wflow.bmi.Bmi):
         if cname[0] in self.bmimodels:
             self.bmimodels[cname[0]].set_value(cname[1], src)
             if self.wrtodisk:
-                report(
-                    numpy2pcr(Scalar, src, -999),
+                pcr.report(
+                    pcr.numpy2pcr(pcr.Scalar, src, -999),
                     long_var_name + "_set_" + str(self.get_current_time()) + ".map",
                 )
 

--- a/wflow/wflow_bmi_combined.py
+++ b/wflow/wflow_bmi_combined.py
@@ -1,14 +1,12 @@
+import configparser
+import json
+import logging
+
+import numpy as np
 import wflow.bmi
 import wflow.wflow_bmi as wfbmi
-
-import wflow
-import os
-from wflow.pcrut import setlogger
-import configparser
-import logging
-import numpy as np
-import json
 from pcraster import *
+from wflow.pcrut import setlogger
 
 
 def iniFileSetUp(configfile):

--- a/wflow/wflow_bmi_combined_mp.py
+++ b/wflow/wflow_bmi_combined_mp.py
@@ -1,10 +1,10 @@
-import wflow.bmi as bmi
-import wflow.wflow_bmi as wfbmi
-import os
-from wflow.pcrut import setlogger
 import configparser
 import logging
+
+import wflow.bmi as bmi
+import wflow.wflow_bmi as wfbmi
 from pcraster import *
+from wflow.pcrut import setlogger
 
 
 def iniFileSetUp(configfile):

--- a/wflow/wflow_bmi_combined_mp.py
+++ b/wflow/wflow_bmi_combined_mp.py
@@ -1,9 +1,11 @@
 import configparser
 import logging
+import os
 
+import numpy as np
 import wflow.bmi as bmi
 import wflow.wflow_bmi as wfbmi
-from pcraster import *
+import pcraster as pcr
 from wflow.pcrut import setlogger
 
 
@@ -424,7 +426,7 @@ class wflowbmi_csdms(bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_start_time())
 
-        return numpy.array(st).max()
+        return np.array(st).max()
 
     def get_current_time(self):
         """
@@ -449,7 +451,7 @@ class wflowbmi_csdms(bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_end_time())
 
-        return numpy.array(st).min()
+        return np.array(st).min()
 
     def get_time_step(self):
         """
@@ -461,7 +463,7 @@ class wflowbmi_csdms(bmi.Bmi):
         for key, value in self.bmimodels.items():
             st.append(self.bmimodels[key].get_time_step())
 
-        return max(st)[0]
+        return max(st)
 
     def get_time_units(self):
         """
@@ -489,8 +491,8 @@ class wflowbmi_csdms(bmi.Bmi):
         if cname[0] in self.bmimodels:
             tmp = self.bmimodels[cname[0]].get_value(cname[1])
             if self.wrtodisk:
-                report(
-                    numpy2pcr(Scalar, tmp, -999),
+                pcr.report(
+                    pcr.numpy2pcr(pcr.Scalar, tmp, -999),
                     long_var_name + "_get_" + str(self.get_current_time()) + ".map",
                 )
             return tmp
@@ -667,8 +669,8 @@ class wflowbmi_csdms(bmi.Bmi):
         if cname[0] in self.bmimodels:
             self.bmimodels[cname[0]].set_value(cname[1], src)
             if self.wrtodisk:
-                report(
-                    numpy2pcr(Scalar, src, -999),
+                pcr.report(
+                    pcr.numpy2pcr(pcr.Scalar, src, -999),
                     long_var_name + "_set_" + str(self.get_current_time()) + ".map",
                 )
 

--- a/wflow/wflow_cqf.py
+++ b/wflow/wflow_cqf.py
@@ -154,7 +154,9 @@ def actEvap_SBM(RootingDepth, WTable, UStoreDepth, FirstZoneDepth, PotTrans, smo
     RestPotEvap = PotTrans - ActEvapSat
 
     # now try unsat store
-    AvailCap = pcr.min(1.0, pcr.max(0.0, (WTable - RootingDepth) / (RootingDepth + 1.0)))
+    AvailCap = pcr.min(
+        1.0, pcr.max(0.0, (WTable - RootingDepth) / (RootingDepth + 1.0))
+    )
 
     # AvailCap = pcr.max(0.0,pcr.ifthenelse(WTable < RootingDepth,  WTable/RootingDepth,  RootingDepth/WTable))
     MaxExtr = AvailCap * UStoreDepth
@@ -702,7 +704,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0)))
+            ** (-0.1875)
             * self.N ** (0.375)
         )
         RiverWidth = W
@@ -728,7 +731,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.DemMax = pcr.readmap(self.Dir + "/staticmaps/wflow_demmax")
         self.DrainageBase = pcr.readmap(self.Dir + "/staticmaps/wflow_demmin")
         self.CC = pcr.min(
-            100.0, -log(1.0 / 0.1 - 1) / pcr.min(-0.1, self.DrainageBase - self.Altitude)
+            100.0,
+            -log(1.0 / 0.1 - 1) / pcr.min(-0.1, self.DrainageBase - self.Altitude),
         )
 
         # if pcr.maptotal(self.RunoffGeneratingThickness <= 0.0):
@@ -814,7 +818,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Aspect = pcr.ifthenelse(self.Aspect <= 0.0, pcr.scalar(0.001), self.Aspect)
         # On Flat areas the Aspect function fails, fill in with average...
         self.Aspect = pcr.ifthenelse(
-            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
+            pcr.defined(self.Aspect),
+            self.Aspect,
+            pcr.areaaverage(self.Aspect, self.TopoId),
         )
 
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
@@ -835,7 +841,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # Add rivers to the WaterFrac, but check with waterfrac map
         self.RiverFrac = pcr.min(
             1.0,
-            pcr.ifthenelse(self.River, (RiverWidth * self.DCL) / (self.xl * self.yl), 0),
+            pcr.ifthenelse(
+                self.River, (RiverWidth * self.DCL) / (self.xl * self.yl), 0
+            ),
         )
         self.WaterFrac = self.WaterFrac - pcr.ifthenelse(
             (self.RiverFrac + self.WaterFrac) > 1.0,
@@ -862,8 +870,12 @@ class WflowModel(pcraster.framework.DynamicModel):
             pcr.report(self.WHC, self.Dir + "/" + self.runId + "/outsum/WHC.map")
 
         pcr.report(self.Cmax, self.Dir + "/" + self.runId + "/outsum/Cmax.map")
-        pcr.report(self.csize, self.Dir + "/" + self.runId + "/outsum/CatchmentSize.map")
-        pcr.report(self.upsize, self.Dir + "/" + self.runId + "/outsum/UpstreamSize.map")
+        pcr.report(
+            self.csize, self.Dir + "/" + self.runId + "/outsum/CatchmentSize.map"
+        )
+        pcr.report(
+            self.upsize, self.Dir + "/" + self.runId + "/outsum/UpstreamSize.map"
+        )
         pcr.report(self.EoverR, self.Dir + "/" + self.runId + "/outsum/EoverR.map")
         pcr.report(
             self.RootingDepth, self.Dir + "/" + self.runId + "/outsum/RootingDepth.map"
@@ -901,7 +913,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         pcr.report(WI, self.Dir + "/" + self.runId + "/outsum/WI.map")
         pcr.report(self.CC, self.Dir + "/" + self.runId + "/outsum/CC.map")
         pcr.report(self.N, self.Dir + "/" + self.runId + "/outsum/N.map")
-        pcr.report(self.RiverFrac, self.Dir + "/" + self.runId + "/outsum/RiverFrac.map")
+        pcr.report(
+            self.RiverFrac, self.Dir + "/" + self.runId + "/outsum/RiverFrac.map"
+        )
 
         pcr.report(self.xl, self.Dir + "/" + self.runId + "/outsum/xl.map")
         pcr.report(self.yl, self.Dir + "/" + self.runId + "/outsum/yl.map")
@@ -1066,7 +1080,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         Zoh = 0.25 * Zom
         d = 0.66 * self.VegetationHeigth
 
-        Ra = 4.72 * pcr.ln((z - d) / Zom) * pcr.ln((z - d) / Zoh) / (1 + 0.54 * self.WindSpeed)
+        Ra = (
+            4.72
+            * pcr.ln((z - d) / Zom)
+            * pcr.ln((z - d) / Zoh)
+            / (1 + 0.54 * self.WindSpeed)
+        )
 
         # Now the actual formula, this is for Interception, rs is zero
         VPD = Esat - Eact
@@ -1092,7 +1111,10 @@ class WflowModel(pcraster.framework.DynamicModel):
         # CQ Specific function!
         ForRs = pcr.exp(0.867 * pcr.ln(InVPD) - 0.000831 * InWave + 2.81)
 
-        Rs = pcr.max(0.5, pcr.min(1000, pcr.ifthenelse(pcr.scalar(self.LandUse) > 1.0, ForRs, PasRs)))
+        Rs = pcr.max(
+            0.5,
+            pcr.min(1000, pcr.ifthenelse(pcr.scalar(self.LandUse) > 1.0, ForRs, PasRs)),
+        )
 
         # No transpiration at nigth, this is of no use to the trees.
         Rs = pcr.ifthenelse(InWave < 10.0, 500, Rs)
@@ -1253,7 +1275,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.FirstZoneThickness - self.FirstZoneDepth / (self.thetaS - self.thetaR),
         )  # Determine actual water depth
         Ksat = self.FirstZoneKsatVer * pcr.exp(-self.f * self.zi)
-        self.DeepKsat = self.FirstZoneKsatVer * pcr.exp(-self.f * self.FirstZoneThickness)
+        self.DeepKsat = self.FirstZoneKsatVer * pcr.exp(
+            -self.f * self.FirstZoneThickness
+        )
 
         # Determine saturation deficit. NB, as noted by Vertessy and Elsenbeer 1997
         # this deficit does NOT take into account the water in the unsaturated zone
@@ -1275,7 +1299,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         # Limit to MaxLeakage/day. Leakage percentage gets bigger if the
         # storm is bigger (macropores start kicking in...
         ActLeakage = pcr.max(
-            0, pcr.min(self.MaxLeakage, self.Transfer * pcr.exp(0.01 * self.Transfer) / e)
+            0,
+            pcr.min(self.MaxLeakage, self.Transfer * pcr.exp(0.01 * self.Transfer) / e),
         )
         self.Transfer = self.Transfer - ActLeakage
         # Now add leakage. to deeper groundwater
@@ -1303,7 +1328,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             waterDem = self.Altitude - (self.zi * 0.001)
             waterLdd = pcr.lddcreate(waterDem, 1e35, 1e35, 1e35, 1e35)
             # waterLdd = pcr.lddcreate(waterDem,1,1,1,1)
-            waterSlope = pcr.max(0.00001, pcr.slope(waterDem) * pcr.celllength() / self.reallength)
+            waterSlope = pcr.max(
+                0.00001, pcr.slope(waterDem) * pcr.celllength() / self.reallength
+            )
 
         self.zi = pcr.max(
             0.0,

--- a/wflow/wflow_cqf.py
+++ b/wflow/wflow_cqf.py
@@ -95,17 +95,12 @@ $Author: schelle $
 $Id: wflow_cqf.py 909 2014-01-16 15:23:32Z schelle $
 $Rev: 909 $
 """
-import numpy
 
-# import pcrut
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-from wflow.wflow_funcs import *
 from wflow.wflow_adapt import *
-
+from wflow.wflow_funcs import *
 
 wflow = "wflow_cqf: "
 wflowVersion = "$Revision: 909 $  $Date: 2014-01-16 16:23:32 +0100 (Thu, 16 Jan 2014) $"

--- a/wflow/wflow_delwaq.py
+++ b/wflow/wflow_delwaq.py
@@ -75,22 +75,13 @@ Command line options::
     
 
 """
-import wflow.wflow_adapt as wflow_adapt
-from wflow.wf_DynamicFramework import *
-
-from datetime import *
-import os
-import os.path
-import shutil
 import getopt
-import time
+import os.path
 import struct
-import shutil
-import builtins
-import configparser
+from datetime import *
 
 from wflow import wf_netcdfio
-
+from wflow.wf_DynamicFramework import *
 
 logger = ""
 volumeMapStack = "vol"

--- a/wflow/wflow_extract.py
+++ b/wflow/wflow_extract.py
@@ -130,12 +130,12 @@ def main(argv=None):
 
     print("recreating static maps ...")
     # Create new ldd using old river network
-    dem = readmap(caseNameNew + "/staticmaps/wflow_dem.map")
+    dem = pcr.readmap(caseNameNew + "/staticmaps/wflow_dem.map")
     # orig low res river
-    riverburn = readmap(caseNameNew + "/staticmaps/wflow_river.map")
+    riverburn = pcr.readmap(caseNameNew + "/staticmaps/wflow_river.map")
     # save it
-    report(riverburn, caseNameNew + "/staticmaps/wflow_riverburnin.map")
-    demburn = cover(ifthen(boolean(riverburn), dem - 600), dem)
+    pcr.report(riverburn, caseNameNew + "/staticmaps/wflow_riverburnin.map")
+    demburn = pcr.cover(pcr.ifthen(pcr.boolean(riverburn), dem - 600), dem)
     print("Creating ldd...")
     ldd = lddcreate_save(
         caseNameNew + "/staticmaps/wflow_ldd.map", demburn, True, 10.0e35
@@ -144,12 +144,12 @@ def main(argv=None):
     ## Find catchment (overall)
     outlet = find_outlet(ldd)
     sub = subcatch(ldd, outlet)
-    report(sub, caseNameNew + "/staticmaps/wflow_catchment.map")
-    report(outlet, caseNameNew + "/staticmaps/wflow_outlet.map")
+    pcr.report(sub, caseNameNew + "/staticmaps/wflow_catchment.map")
+    pcr.report(outlet, caseNameNew + "/staticmaps/wflow_outlet.map")
     # os.system("col2map --clone " + caseNameNew + "/staticmaps/wflow_subcatch.map " + caseNameNew + "/staticmaps/gauges.col " + caseNameNew + "/staticmaps/wflow_gauges.map")
-    gmap = readmap(caseNameNew + "/staticmaps/wflow_gauges.map")
+    gmap = pcr.readmap(caseNameNew + "/staticmaps/wflow_gauges.map")
     scatch = subcatch(ldd, gmap)
-    report(scatch, caseNameNew + "/staticmaps/wflow_subcatch.map")
+    pcr.report(scatch, caseNameNew + "/staticmaps/wflow_subcatch.map")
 
 
 if __name__ == "__main__":

--- a/wflow/wflow_extract.py
+++ b/wflow/wflow_extract.py
@@ -34,12 +34,11 @@ The script uses the pcraster resample program to reduce the maps.
 """
 
 
-from wflow.wflow_lib import *
-import sys
-import os
-import os.path
-import glob
 import getopt
+import glob
+import os.path
+
+from wflow.wflow_lib import *
 
 
 def usage(*args):

--- a/wflow/wflow_fit.py
+++ b/wflow/wflow_fit.py
@@ -59,20 +59,16 @@ $Rev: 669 $
 """
 
 
+import csv
+import getopt
+import os.path
+import sys
+
+import numpy as np
 import pylab
 import scipy.optimize
-
 import wflow.pcrut as pcrut
 import wflow.stats as stats
-
-
-import os.path
-import numpy as np
-
-
-import getopt
-import sys
-import csv
 
 
 # TODO: do not read results from file

--- a/wflow/wflow_fit_brute.py
+++ b/wflow/wflow_fit_brute.py
@@ -59,16 +59,15 @@ $Rev: 785 $
 """
 
 
-import wflow.pcrut as pcrut
-import wflow.stats as stats
-
-
+import csv
+import getopt
 import os.path
+import sys
+
 import numpy as np
 import pylab
-import getopt
-import sys
-import csv
+import wflow.pcrut as pcrut
+import wflow.stats as stats
 
 
 # TODO: do not read results from file

--- a/wflow/wflow_floodmap.py
+++ b/wflow/wflow_floodmap.py
@@ -322,11 +322,15 @@ class WflowModel(pcraster.framework.DynamicModel):
                 self.distfromriv > self.maxdist, 0.0, self.FloodDepth
             )
             self.FloodDepth = pcr.ifthen(self.FloodDepth > 0.0, self.FloodDepth)
-            self.FloodExtent = pcr.ifthenelse(self.FloodDepth > 0.0, pcr.boolean(1), pcr.boolean(0))
+            self.FloodExtent = pcr.ifthenelse(
+                self.FloodDepth > 0.0, pcr.boolean(1), pcr.boolean(0)
+            )
 
             # Keep track of af depth and extent
             self.MaxDepth = pcr.max(self.MaxDepth, pcr.cover(self.FloodDepth, 0))
-            self.MaxExt = pcr.max(pcr.scalar(self.MaxExt), pcr.scalar(pcr.cover(self.FloodExtent, 0)))
+            self.MaxExt = pcr.max(
+                pcr.scalar(self.MaxExt), pcr.scalar(pcr.cover(self.FloodExtent, 0))
+            )
 
         # reporting of maps is done by the framework (see ini file)
 

--- a/wflow/wflow_floodmap.py
+++ b/wflow/wflow_floodmap.py
@@ -58,14 +58,9 @@ $Rev: 916 $
 
 # TODO: update to update framework
 
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-
-# import scipy
-
 from wflow.wflow_adapt import *
 
 

--- a/wflow/wflow_funcs.py
+++ b/wflow/wflow_funcs.py
@@ -126,7 +126,7 @@ def rainfall_interception_modrut(
     pt = 0.1 * p
 
     # Amount of P that falls on the canopy
-    Pfrac = pcr.max((1 - p - pt),0) * Precipitation
+    Pfrac = pcr.max((1 - p - pt), 0) * Precipitation
 
     # S cannot be larger than Cmax, no gravity drainage below that
     DD = pcr.ifthenelse(CanopyStorage > Cmax, CanopyStorage - Cmax, 0.0)

--- a/wflow/wflow_funcs.py
+++ b/wflow/wflow_funcs.py
@@ -25,12 +25,7 @@ that may be used within the wflow models
 
 from numpy import *
 
-
-from pcraster import *
 from pcraster.framework import *
-
-
-# import scipy
 
 
 def rainfall_interception_hbv(Rainfall, PotEvaporation, Cmax, InterceptionStorage):

--- a/wflow/wflow_gr4.py
+++ b/wflow/wflow_gr4.py
@@ -36,6 +36,7 @@ NOTES
 
 import os.path
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -53,7 +54,7 @@ def pcr_tanh(x):
     define tanh for pcraster objects
     
     """
-    return (exp(x) - exp(-x)) / (exp(x) + exp(-x))
+    return (pcr.exp(x) - pcr.exp(-x)) / (pcr.exp(x) + pcr.exp(-x))
 
 
 def initUH1(X4, D):
@@ -69,7 +70,7 @@ def initUH1(X4, D):
     """
     NH = int(numpy.ceil(X4))
 
-    t = arange(1, NH + 1)
+    t = np.arange(1, NH + 1)
     SH1 = numpy.minimum(1.0, (t / X4) ** D)
 
     # Use numpy.diff to get the UH, insert value at zero to complete
@@ -93,8 +94,8 @@ def initUH2(X4, D):
     """
     NH = int(numpy.ceil(X4))
 
-    t1 = arange(1, NH)
-    t2 = arange(NH, 2 * NH + 1)
+    t1 = np.arange(1, NH)
+    t2 = np.arange(NH, 2 * NH + 1)
 
     SH2_1 = 0.5 * (t1 / X4) ** D
     SH2_2 = 1 - 0.5 * (numpy.maximum(0, 2 - t2 / X4)) ** D
@@ -124,12 +125,12 @@ def mk_qres(N):
     uhq = []
 
     for i in range(0, N):
-        uhq.append(cover(0.0))
+        uhq.append(pcr.cover(0.0))
 
     return uhq
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. This is your work!
   """
@@ -142,11 +143,11 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
       
       """
-        DynamicModel.__init__(self)
+        pcraster.framework.DynamicModel.__init__(self)
 
         self.caseName = os.path.abspath(Dir)
         self.clonemappath = os.path.join(os.path.abspath(Dir), "staticmaps", cloneMap)
-        setclone(self.clonemappath)
+        pcr.setclone(self.clonemappath)
         self.runId = RunDir
         self.Dir = os.path.abspath(Dir)
         self.configfile = configfile
@@ -231,9 +232,9 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
-        self.thestep = scalar(0)
-        self.ZeroMap = cover(0.0)
+        pcr.setglobaloption("unittrue")
+        self.thestep = pcr.scalar(0)
+        self.ZeroMap = pcr.cover(0.0)
 
         self.timestepsecs = int(configget(self.config, "model", "timestepsecs", "3600"))
         self.basetimestep = 3600
@@ -244,7 +245,7 @@ class WflowModel(DynamicModel):
             self.config, "inputmapstacks", "Temperature", "/inmaps/TEMP"
         )
         self.intbl = configget(self.config, "model", "intbl", "intbl")
-        self.Altitude = readmap(self.Dir + "/staticmaps/wflow_dem")
+        self.Altitude = pcr.readmap(self.Dir + "/staticmaps/wflow_dem")
 
         wflow_subcatch = configget(
             self.config, "model", "wflow_subcatch", "/staticmaps/wflow_subcatch.map"
@@ -262,10 +263,10 @@ class WflowModel(DynamicModel):
             self.config, "inputmapstacks", "EvapoTranspiration", "/inmaps/PET"
         )  # timeseries for rainfall"/inmaps/PET"          # potential evapotranspiration
         sizeinmetres = int(configget(self.config, "layout", "sizeinmetres", "0"))
-        subcatch = ordinal(
-            readmap(self.Dir + wflow_subcatch)
+        subcatch = pcr.ordinal(
+            pcr.readmap(self.Dir + wflow_subcatch)
         )  # Determines the area of calculations (all cells > 0)
-        subcatch = ifthen(subcatch > 0, subcatch)
+        subcatch = pcr.ifthen(subcatch > 0, subcatch)
         self.xl, self.yl, self.reallength = pcrut.detRealCellLength(
             self.ZeroMap, sizeinmetres
         )
@@ -273,13 +274,13 @@ class WflowModel(DynamicModel):
             self.reallength * self.reallength * 0.001
         ) / self.timestepsecs  # m3/s
 
-        self.LandUse = readmap(
+        self.LandUse = pcr.readmap(
             self.Dir + wflow_landuse
         )  #: Map with lan-use/cover classes
-        self.LandUse = cover(self.LandUse, nominal(ordinal(subcatch) > 0))
-        self.Soil = readmap(self.Dir + wflow_soil)  #: Map with soil classes
-        self.Soil = cover(self.Soil, nominal(ordinal(subcatch) > 0))
-        self.OutputId = readmap(self.Dir + wflow_subcatch)  # location of subcatchment
+        self.LandUse = pcr.cover(self.LandUse, pcr.nominal(pcr.ordinal(subcatch) > 0))
+        self.Soil = pcr.readmap(self.Dir + wflow_soil)  #: Map with soil classes
+        self.Soil = pcr.cover(self.Soil, pcr.nominal(pcr.ordinal(subcatch) > 0))
+        self.OutputId = pcr.readmap(self.Dir + wflow_subcatch)  # location of subcatchment
 
         # hourly time step
         self.dt = int(configget(self.config, "gr4", "dt", "1"))
@@ -367,19 +368,19 @@ class WflowModel(DynamicModel):
         )
         self.thestep = self.thestep + 1
 
-        self.Precipitation = cover(self.wf_readmap(self.P_mapstack, 0.0), 0.0)
-        self.PotEvaporation = cover(self.wf_readmap(self.PET_mapstack, 0.0), 0.0)
+        self.Precipitation = pcr.cover(self.wf_readmap(self.P_mapstack, 0.0), 0.0)
+        self.PotEvaporation = pcr.cover(self.wf_readmap(self.PET_mapstack, 0.0), 0.0)
 
         # ROUTING WATER AND PRODUCTION RESERVOIR PERCOLATION ========================================================
 
-        self.Pn = ifthenelse(
+        self.Pn = pcr.ifthenelse(
             self.Precipitation >= self.PotEvaporation,
             self.Precipitation - self.PotEvaporation,
-            scalar(0.0),
+            pcr.scalar(0.0),
         )
-        self.En = ifthenelse(
+        self.En = pcr.ifthenelse(
             self.Precipitation >= self.PotEvaporation,
-            scalar(0.0),
+            pcr.scalar(0.0),
             self.PotEvaporation - self.Precipitation,
         )
         self.Ps = (self.X1 * (1 - (self.S_X1) ** 2) * pcr_tanh(self.Pn / self.X1)) / (
@@ -388,18 +389,18 @@ class WflowModel(DynamicModel):
         self.Es = (
             self.S_X1 * self.X1 * (2 - self.S_X1) * pcr_tanh(self.En / self.X1)
         ) / (1 + (1 - self.S_X1) * pcr_tanh(self.En / self.X1))
-        self.Ps = ifthenelse(
-            self.Precipitation >= self.PotEvaporation, self.Ps, scalar(0.0)
+        self.Ps = pcr.ifthenelse(
+            self.Precipitation >= self.PotEvaporation, self.Ps, pcr.scalar(0.0)
         )
-        self.Es = ifthenelse(
-            self.Precipitation >= self.PotEvaporation, scalar(0.0), self.Es
+        self.Es = pcr.ifthenelse(
+            self.Precipitation >= self.PotEvaporation, pcr.scalar(0.0), self.Es
         )
 
         self.Sprim_X1 = (
             self.S_X1 + ((self.Ps - self.Es) * self.dt) / self.X1
         )  # reservoir new content
         # Filter out value < 0 in self.Sprim_X1
-        self.Sprim_X1 = max(0.0, self.Sprim_X1)
+        self.Sprim_X1 = pcr.max(0.0, self.Sprim_X1)
 
         self.Perc = (
             self.Sprim_X1 * self.X1 * (1 - (1 + (self.Sprim_X1 / 5.25) ** 4) ** -0.25)
@@ -435,16 +436,16 @@ class WflowModel(DynamicModel):
             self.Rprim_X3 * self.X3 * (1.0 - (1.0 + (self.Rprim_X3) ** 4) ** -0.25)
         )  # routing output
         self.R_X3 = self.Rprim_X3 - self.Qr / self.X3  # new routing reservoir level
-        self.Qd = max(0.0, self.Q1 + self.F)  # flow component Qd
+        self.Qd = pcr.max(0.0, self.Q1 + self.F)  # flow component Qd
         self.Q = self.Qr + self.Qd  # total flow Q in mm/hr
         # Updated this line to get total Q per basin
-        self.SurfaceRunoff = areatotal(self.Q * self.ToCubic, self.OutputId)
+        self.SurfaceRunoff = pcr.areatotal(self.Q * self.ToCubic, self.OutputId)
 
         # Remove first item from the UH stacks and add a new empty one at the end
         self.QUH1 = delete(self.QUH1, 0)
-        self.QUH1 = append(self.QUH1, cover(0.0))
+        self.QUH1 = append(self.QUH1, pcr.cover(0.0))
         self.QUH2 = delete(self.QUH2, 0)
-        self.QUH2 = append(self.QUH2, cover(0.0))
+        self.QUH2 = append(self.QUH2, pcr.cover(0.0))
 
 
 # The main function is used to run the program from the command line

--- a/wflow/wflow_gr4.py
+++ b/wflow/wflow_gr4.py
@@ -280,7 +280,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.LandUse = pcr.cover(self.LandUse, pcr.nominal(pcr.ordinal(subcatch) > 0))
         self.Soil = pcr.readmap(self.Dir + wflow_soil)  #: Map with soil classes
         self.Soil = pcr.cover(self.Soil, pcr.nominal(pcr.ordinal(subcatch) > 0))
-        self.OutputId = pcr.readmap(self.Dir + wflow_subcatch)  # location of subcatchment
+        self.OutputId = pcr.readmap(
+            self.Dir + wflow_subcatch
+        )  # location of subcatchment
 
         # hourly time step
         self.dt = int(configget(self.config, "gr4", "dt", "1"))

--- a/wflow/wflow_gr4.py
+++ b/wflow/wflow_gr4.py
@@ -34,15 +34,10 @@ NOTES
 
 """
 
-import numpy
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-
-# import scipy
 
 
 def usage(*args):

--- a/wflow/wflow_hbv.py
+++ b/wflow/wflow_hbv.py
@@ -510,7 +510,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True
         )  # location of subcatchment
 
-        self.ZeroMap = 0.0 * pcr.scalar(pcr.defined(self.Altitude))  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(
+            pcr.defined(self.Altitude)
+        )  # map with only zero's
 
         # 3: Input time series ###################################################
         self.P_mapstack = self.Dir + configget(
@@ -621,10 +623,15 @@ class WflowModel(pcraster.framework.DynamicModel):
                 + str(self.nrresComplex)
                 + " complex reservoirs found."
             )
-            self.ReserVoirDownstreamLocs = pcr.downstream(self.TopoLdd, self.ReserVoirLocs)
+            self.ReserVoirDownstreamLocs = pcr.downstream(
+                self.TopoLdd, self.ReserVoirLocs
+            )
             self.TopoLddOrg = self.TopoLdd
             self.TopoLdd = pcr.lddrepair(
-                pcr.cover(pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)), self.TopoLdd)
+                pcr.cover(
+                    pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)),
+                    self.TopoLdd,
+                )
             )
 
         # HBV Soil params
@@ -845,7 +852,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0)))
+            ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
@@ -891,7 +899,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
             ds = pcr.downstream(self.TopoLdd, self.TopoId)
             usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
+            self.TopoLdd = pcr.lddrepair(
+                pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd)
+            )
 
         # Used to seperate output per LandUse/management classes
         # OutZones = self.LandUse
@@ -931,7 +941,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Aspect = pcr.ifthenelse(self.Aspect <= 0.0, pcr.scalar(0.001), self.Aspect)
         # On Flat areas the Aspect function fails, fill in with average...
         self.Aspect = pcr.ifthenelse(
-            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
+            pcr.defined(self.Aspect),
+            self.Aspect,
+            pcr.areaaverage(self.Aspect, self.TopoId),
         )
 
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
@@ -1100,9 +1112,12 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         RainFrac = pcr.ifthenelse(
             1.0 * self.TTI == 0.0,
-            pcr.ifthenelse(self.Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)),
+            pcr.ifthenelse(
+                self.Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)
+            ),
             pcr.min(
-                (self.Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, pcr.scalar(1.0)
+                (self.Temperature - (self.TT - self.TTI / 2.0)) / self.TTI,
+                pcr.scalar(1.0),
             ),
         )
         RainFrac = pcr.max(
@@ -1289,7 +1304,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.RealQuickFlow = self.ZeroMap
         else:
             self.QuickFlow = self.KQuickFlow * self.UpperZoneStorage
-            self.RealQuickFlow = pcr.max(0, self.K0 * (self.UpperZoneStorage - self.SUZ))
+            self.RealQuickFlow = pcr.max(
+                0, self.K0 * (self.UpperZoneStorage - self.SUZ)
+            )
             self.UpperZoneStorage = (
                 self.UpperZoneStorage - self.QuickFlow - self.RealQuickFlow
             )

--- a/wflow/wflow_hbv.py
+++ b/wflow/wflow_hbv.py
@@ -79,20 +79,10 @@ wflow_hbv::
 
 """
 
-import numpy
-import sys
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-from wflow.wflow_adapt import *
-
-# import scipy
-# import pcrut
-
 
 wflow = "wflow_hbv"
 

--- a/wflow/wflow_hbvl.py
+++ b/wflow/wflow_hbvl.py
@@ -74,18 +74,11 @@ wflow_hbv::
 
 """
 
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-from wflow.wf_DynamicFramework import *
-from wflow.wflow_adapt import *
+
 from .wflow_adapt import *
-
-# import scipy
-# import pcrut
-
 
 wflow = "wflow_hbv"
 

--- a/wflow/wflow_hbvl.py
+++ b/wflow/wflow_hbvl.py
@@ -349,7 +349,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True
         )  # location of subcatchment
 
-        self.ZeroMap = 0.0 * pcr.scalar(pcr.defined(self.Altitude))  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(
+            pcr.defined(self.Altitude)
+        )  # map with only zero's
 
         # 3: Input time series ###################################################
         self.P_mapstack = self.Dir + configget(
@@ -647,9 +649,12 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         RainFrac = pcr.ifthenelse(
             1.0 * self.TTI == 0.0,
-            pcr.ifthenelse(self.Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)),
+            pcr.ifthenelse(
+                self.Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)
+            ),
             pcr.min(
-                (self.Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, pcr.scalar(1.0)
+                (self.Temperature - (self.TT - self.TTI / 2.0)) / self.TTI,
+                pcr.scalar(1.0),
             ),
         )
         RainFrac = pcr.max(

--- a/wflow/wflow_lib.py
+++ b/wflow/wflow_lib.py
@@ -133,11 +133,15 @@ def simplereservoir(
     inflow = pcr.ifthen(pcr.boolean(ReserVoirLocs), inflow)
 
     prec_av = pcr.cover(
-        pcr.ifthen(pcr.boolean(ReserVoirLocs), pcr.areaaverage(precip, ReservoirSimpleAreas)),
+        pcr.ifthen(
+            pcr.boolean(ReserVoirLocs), pcr.areaaverage(precip, ReservoirSimpleAreas)
+        ),
         pcr.scalar(0.0),
     )
     pet_av = pcr.cover(
-        pcr.ifthen(pcr.boolean(ReserVoirLocs), pcr.areaaverage(pet, ReservoirSimpleAreas)),
+        pcr.ifthen(
+            pcr.boolean(ReserVoirLocs), pcr.areaaverage(pet, ReservoirSimpleAreas)
+        ),
         pcr.scalar(0.0),
     )
 
@@ -230,8 +234,12 @@ def complexreservoir(
 
     inflow = pcr.ifthen(pcr.boolean(ReserVoirLocs), inflow)
 
-    prec_av = pcr.ifthen(pcr.boolean(ReserVoirLocs), pcr.areaaverage(precip, ReservoirComplexAreas))
-    pet_av = pcr.ifthen(pcr.boolean(ReserVoirLocs), pcr.areaaverage(pet, ReservoirComplexAreas))
+    prec_av = pcr.ifthen(
+        pcr.boolean(ReserVoirLocs), pcr.areaaverage(precip, ReservoirComplexAreas)
+    )
+    pet_av = pcr.ifthen(
+        pcr.boolean(ReserVoirLocs), pcr.areaaverage(pet, ReservoirComplexAreas)
+    )
 
     np_reslocs = pcr.pcr2numpy(ReserVoirLocs, 0.0)
     np_linkedreslocs = pcr.pcr2numpy(LinkedReserVoirLocs, 0.0)
@@ -274,7 +282,7 @@ def complexreservoir(
         np_outflow = pcr.pcr2numpy(outflow, np.nan)
         np_outflow_linked = np_reslocs * 0.0
 
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid="ignore"):
             if np_outflow[np_outflow < 0] is not None:
                 np_outflow_linked[
                     np.in1d(np_reslocs, np_linkedreslocs[np_outflow < 0]).reshape(
@@ -301,7 +309,7 @@ def complexreservoir(
         )
 
         np_outflow_nz = np_outflow * 0.0
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid="ignore"):
             np_outflow_nz[np_outflow > 0] = np_outflow[np_outflow > 0]
         _outflow.append(np_outflow_nz)
 
@@ -528,7 +536,9 @@ def riverlength(ldd, order):
     """
     strorder = pcr.streamorder(ldd)
     strorder = pcr.ifthen(strorder >= pcr.ordinal(order), strorder)
-    dist = pcr.max(pcr.celllength(), pcr.ifthen(pcr.boolean(strorder), pcr.downstreamdist(ldd)))
+    dist = pcr.max(
+        pcr.celllength(), pcr.ifthen(pcr.boolean(strorder), pcr.downstreamdist(ldd))
+    )
 
     return pcr.catchmenttotal(pcr.cover(dist, 0), ldd), dist, strorder
 
@@ -552,11 +562,18 @@ def upscale_riverlength(ldd, order, factor):
 
     strorder = pcr.streamorder(ldd)
     strorder = pcr.ifthen(strorder >= order, strorder)
-    dist = pcr.cover(pcr.max(pcr.celllength(), pcr.ifthen(pcr.boolean(strorder), pcr.downstreamdist(ldd))), 0)
+    dist = pcr.cover(
+        pcr.max(
+            pcr.celllength(), pcr.ifthen(pcr.boolean(strorder), pcr.downstreamdist(ldd))
+        ),
+        0,
+    )
     totdist = pcr.max(
         pcr.ifthen(
             pcr.boolean(strorder),
-            pcr.windowtotal(pcr.ifthen(pcr.boolean(strorder), dist), pcr.celllength() * factor),
+            pcr.windowtotal(
+                pcr.ifthen(pcr.boolean(strorder), dist), pcr.celllength() * factor
+            ),
         ),
         dist,
     )
@@ -648,7 +665,9 @@ def find_outlet(ldd):
         - outlet map (single point in the map)
     """
     largest = pcr.mapmaximum(pcr.catchmenttotal(pcr.spatial(pcr.scalar(1.0)), ldd))
-    outlet = pcr.ifthen(pcr.catchmenttotal(1.0, ldd) == largest, pcr.spatial(pcr.scalar(1.0)))
+    outlet = pcr.ifthen(
+        pcr.catchmenttotal(1.0, ldd) == largest, pcr.spatial(pcr.scalar(1.0))
+    )
 
     return outlet
 
@@ -793,7 +812,9 @@ def subcatch_stream(
     elif assign_existing:
         # unaccounted areas are added to largest nearest draining basin
         if up_area is None:
-            up_area = pcr.ifthen(pcr.boolean(pcr.cover(stream_ge, 0)), pcr.accuflux(ldd, 1))
+            up_area = pcr.ifthen(
+                pcr.boolean(pcr.cover(stream_ge, 0)), pcr.accuflux(ldd, 1)
+            )
         riverid = pcr.ifthen(pcr.boolean(pcr.cover(stream_ge, 0)), subcatch)
 
         friction = 1.0 / pcr.scalar(
@@ -801,7 +822,10 @@ def subcatch_stream(
         )  # *(pcr.scalar(ldd)*0+1)
         delta = pcr.ifthen(
             pcr.scalar(ldd) >= 0,
-            pcr.ifthen(pcr.cover(subcatch, 0) == 0, pcr.spreadzone(pcr.cover(riverid, 0), 0, friction)),
+            pcr.ifthen(
+                pcr.cover(subcatch, 0) == 0,
+                pcr.spreadzone(pcr.cover(riverid, 0), 0, friction),
+            ),
         )
         subcatch = pcr.ifthenelse(pcr.boolean(pcr.cover(subcatch, 0)), subcatch, delta)
 
@@ -836,7 +860,13 @@ def subcatch_order_a(ldd, oorder):
     pts = pcr.ifthen((pcr.scalar(sttd) - pcr.scalar(stt)) > 0.0, sttd)
     dif = pcr.upstream(
         ldd,
-        pcr.cover(pcr.ifthen(large, pcr.uniqueid(pcr.boolean(pcr.ifthen(stt == pcr.ordinal(oorder), pts)))), 0),
+        pcr.cover(
+            pcr.ifthen(
+                large,
+                pcr.uniqueid(pcr.boolean(pcr.ifthen(stt == pcr.ordinal(oorder), pts))),
+            ),
+            0,
+        ),
     )
     dif = pcr.cover(pcr.scalar(outl), dif)  # Add catchment outlet
     dif = pcr.ordinal(pcr.uniqueid(pcr.boolean(dif)))
@@ -880,20 +910,31 @@ def subcatch_order_b(
     if fill:
         for order in range(oorder, maxorder):
             m_pts = pcr.ifthen((pcr.scalar(sttd) - pcr.scalar(order)) > 0.0, sttd)
-            m_dif = pcr.uniqueid(pcr.boolean(pcr.ifthen(stt == pcr.ordinal(order), m_pts)))
+            m_dif = pcr.uniqueid(
+                pcr.boolean(pcr.ifthen(stt == pcr.ordinal(order), m_pts))
+            )
             dif = pcr.uniqueid(pcr.boolean(pcr.cover(m_dif, dif)))
 
         for myorder in range(oorder - 1, stoporder, -1):
             sc = pcr.subcatchment(ldd, pcr.nominal(dif))
             m_pts = pcr.ifthen((pcr.scalar(sttd) - pcr.scalar(stt)) > 0.0, sttd)
-            m_dif = pcr.uniqueid(pcr.boolean(pcr.ifthen(stt == pcr.ordinal(myorder - 1), m_pts)))
-            dif = pcr.uniqueid(pcr.boolean(pcr.cover(pcr.ifthen(pcr.scalar(sc) == 0, m_dif), dif)))
+            m_dif = pcr.uniqueid(
+                pcr.boolean(pcr.ifthen(stt == pcr.ordinal(myorder - 1), m_pts))
+            )
+            dif = pcr.uniqueid(
+                pcr.boolean(pcr.cover(pcr.ifthen(pcr.scalar(sc) == 0, m_dif), dif))
+            )
 
         if fillcomplete:
             sc = pcr.subcatchment(ldd, pcr.nominal(dif))
             cs, m_dif, stt = subcatch_order_a(ldd, stoporder)
             dif = pcr.uniqueid(
-                pcr.boolean(pcr.cover(pcr.ifthen(pcr.scalar(sc) == 0, pcr.ordinal(m_dif)), pcr.ordinal(dif)))
+                pcr.boolean(
+                    pcr.cover(
+                        pcr.ifthen(pcr.scalar(sc) == 0, pcr.ordinal(m_dif)),
+                        pcr.ordinal(dif),
+                    )
+                )
             )
 
     scsize = pcr.catchmenttotal(1, ldd)
@@ -997,7 +1038,7 @@ def points_to_map(in_map, xcor, ycor, tolerance):
     # Loop over points and "burn in" map
     for n in range(0, xcor.size):
         if Verbose:
-            print (n)
+            print(n)
         diffx = x - xcor[n]
         diffy = y - ycor[n]
         col_ = np.absolute(diffx) <= (cell_length * tolerance)  # cellsize
@@ -1030,7 +1071,9 @@ def detdrainlength(ldd, xl, yl):
         pcr.ifthenelse(
             draindir == 8,
             yl,
-            pcr.ifthenelse(draindir == 4, xl, pcr.ifthenelse(draindir == 6, xl, slantlength)),
+            pcr.ifthenelse(
+                draindir == 4, xl, pcr.ifthenelse(draindir == 6, xl, slantlength)
+            ),
         ),
     )
 
@@ -1060,7 +1103,9 @@ def detdrainwidth(ldd, xl, yl):
         pcr.ifthenelse(
             draindir == 8,
             xl,
-            pcr.ifthenelse(draindir == 4, yl, pcr.ifthenelse(draindir == 6, yl, slantwidth)),
+            pcr.ifthenelse(
+                draindir == 4, yl, pcr.ifthenelse(draindir == 6, yl, slantwidth)
+            ),
         ),
     )
     return drainwidth
@@ -1076,7 +1121,9 @@ def classify(
 
     result = pcr.ordinal(pcr.cover(-1))
     for l, u, c in zip(lower, upper, classes):
-        result = pcr.cover(pcr.ifthen(inmap >= l, pcr.ifthen(inmap < u, pcr.ordinal(c))), result)
+        result = pcr.cover(
+            pcr.ifthen(inmap >= l, pcr.ifthen(inmap < u, pcr.ordinal(c))), result
+        )
 
     return pcr.ifthen(result >= 0, result)
 
@@ -1103,7 +1150,9 @@ def derive_HAND(dem, ldd, accuThreshold, rivers=None, basin=None):
             according to D8 directions
     """
     if rivers is None:
-        stream = pcr.ifthenelse(pcr.accuflux(ldd, 1) >= accuThreshold, pcr.boolean(1), pcr.boolean(0))
+        stream = pcr.ifthenelse(
+            pcr.accuflux(ldd, 1) >= accuThreshold, pcr.boolean(1), pcr.boolean(0)
+        )
     else:
         stream = pcr.boolean(pcr.cover(rivers, 0))
 
@@ -1112,7 +1161,9 @@ def derive_HAND(dem, ldd, accuThreshold, rivers=None, basin=None):
         up_elevation = pcr.scalar(pcr.subcatchment(ldd, height_river))
     else:
         drainage_surf = pcr.ifthen(rivers, pcr.accuflux(ldd, 1))
-        weight = 1.0 / pcr.scalar(pcr.spreadzone(pcr.cover(pcr.ordinal(drainage_surf), 0), 0, 0))
+        weight = 1.0 / pcr.scalar(
+            pcr.spreadzone(pcr.cover(pcr.ordinal(drainage_surf), 0), 0, 0)
+        )
         up_elevation = pcr.ifthenelse(
             basin,
             pcr.scalar(pcr.subcatchment(ldd, height_river)),

--- a/wflow/wflow_lib.py
+++ b/wflow/wflow_lib.py
@@ -33,17 +33,13 @@ $Id: wflow_lib.py 808 2013-10-04 19:42:43Z schelle $
 $Rev: 808 $
 """
 
-
-import os
+import gzip
 import os.path
-import sys
+import zipfile
 
-import osgeo.gdal as gdal
-from osgeo.gdalconst import *
-from pcraster import *
-from pcraster.framework import *
 import numpy as np
-import gzip, zipfile
+import osgeo.gdal as gdal
+from pcraster.framework import *
 
 
 def pt_flow_in_river(ldd, river):

--- a/wflow/wflow_lintul.py
+++ b/wflow/wflow_lintul.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python
 #
 
-from math import pi
-import math
-import os
 import os.path
-import getopt
+from math import pi
 
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-import time
 
 """
 

--- a/wflow/wflow_lintul.py
+++ b/wflow/wflow_lintul.py
@@ -2,8 +2,9 @@
 #
 
 import os.path
-from math import pi
+import math
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -63,7 +64,7 @@ def NOTNUL_pcr(pcr_map):
     Sander de Vries, March 2018
     """
     checkzeros = pcr_map == 0.0
-    checkzeros_scalar = scalar(checkzeros)
+    checkzeros_scalar = pcr.scalar(checkzeros)
     pcr_map += checkzeros_scalar
     return pcr_map
 
@@ -81,8 +82,8 @@ def astro_py(DAY, LAT):
     """
 
     # SINE AND COSINE OF LATITUDE
-    sinLAT = math.sin(pi * LAT / 180.0)
-    cosLAT = math.cos(pi * LAT / 180.0)
+    sinLAT = math.sin(math.pi * LAT / 180.0)
+    cosLAT = math.cos(math.pi * LAT / 180.0)
 
     # MAXIMAL SINE OF DECLINATION
     sinDCM = math.sin(math.pi * 23.45 / 180.0)
@@ -92,7 +93,7 @@ def astro_py(DAY, LAT):
     # SINDEC = -SINDCM * cos(2.* PI * (DAY+10.)/365.)
     # The '9' below (instead of 10) keeps things in sync with FST...
     # Todo: try to understand this at a certain point... for now it works perfectly.
-    sinDEC = -sinDCM * math.cos(2.0 * pi * (DAY + 11.0) / 365.0)
+    sinDEC = -sinDCM * math.cos(2.0 * math.pi * (DAY + 11.0) / 365.0)
     cosDEC = math.sqrt(1.0 - sinDEC * sinDEC)
 
     # THE TERMS A AND B ACCORDING TO EQUATION 3.3
@@ -101,7 +102,7 @@ def astro_py(DAY, LAT):
     B = cosLAT * cosDEC
 
     # DAYLENGTH ACCORDING TO EQUATION 3.6.
-    DAYL = 12.0 * (1.0 + (2.0 / pi) * math.asin(A / B))
+    DAYL = 12.0 * (1.0 + (2.0 / math.pi) * math.asin(A / B))
 
     return DAYL
 
@@ -168,7 +169,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
     wflow_lintul
     """
@@ -181,8 +182,8 @@ class WflowModel(DynamicModel):
         may be added by you if needed.
 
         """
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -478,7 +479,7 @@ class WflowModel(DynamicModel):
         """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
         self.timestepsecs = int(
             configget(self.config, "model", "timestepsecs", "86400")
@@ -498,7 +499,7 @@ class WflowModel(DynamicModel):
             os.path.join(self.Dir, wflow_ricemask), 0.0, fail=True
         )
         # Create a PCRaster boolean map too:
-        self.ricemask_BOOL = boolean(self.ricemask)
+        self.ricemask_BOOL = pcr.boolean(self.ricemask)
         self.Pausedays = self.Pause + 1
 
         # Calculate initial development stage (at the time of transplanting)
@@ -537,7 +538,7 @@ class WflowModel(DynamicModel):
         if self.reinit == 1:
             self.logger.info("Setting initial conditions to default")
             for s in self.stateVariables():
-                exec("self." + s + " = cover(0.0)")
+                exec("self." + s + " = pcr.cover(0.0)")
         else:
             self.wf_resume(self.Dir + "/instate/")
 
@@ -546,7 +547,7 @@ class WflowModel(DynamicModel):
             # except:
             #    self.logger.warning("Cannot load initial states, setting to default")
             #    for s in self.stateVariables():
-            #        exec "self." + s + " = cover(1.0)"
+            #        exec "self." + s + " = pcr.cover(1.0)"
 
     def default_summarymaps(self):
         """
@@ -602,17 +603,17 @@ class WflowModel(DynamicModel):
 
         # The first season is defined here as starting on November 1. The 2md and 3rd season are following the 1st with break periods of <self.Pausedays> days,
         # to account for the time that the farmer needs for rice harvesting and crop establishment.
-        # self.Season      += ifthenelse(Calc_RainSum, self.ricemask, 0.)
+        # self.Season      += pcr.ifthenelse(Calc_RainSum, self.ricemask, 0.)
         FirstSeason = self.Season == 1
         SecondSeason = self.Season == 2
         ThirdSeason = self.Season == 3
-        self.Season += ifthenelse(
+        self.Season += pcr.ifthenelse(
             EnoughRain, self.ricemask, 0.0
         )  # beware, this variable is also modified in another equation
         # Add rain when the precipitation sum is positive but still below the threshold for crop establishment, reset to 0. when this is no longer the case.
         self.PSUM = (
-            self.PSUM + ifthenelse(KeepAddingRain, self.RAIN, 0.0)
-        ) * ifthenelse(KeepAddingRain, scalar(1.0), 0.0)
+            self.PSUM + pcr.ifthenelse(KeepAddingRain, self.RAIN, 0.0)
+        ) * pcr.ifthenelse(KeepAddingRain, pcr.scalar(1.0), 0.0)
 
         # Initializing crop harvest:
         # If a fixed planting and a fixed harvest date are forced for the whole catchment:
@@ -637,12 +638,12 @@ class WflowModel(DynamicModel):
             # but normally from a crop profile forcing variable.
             StartNow = DOY == self.CropStartDOY
             CropStartNow = StartNow & self.ricemask_BOOL
-            CropStartNow_scalar = scalar(CropStartNow)
+            CropStartNow_scalar = pcr.scalar(CropStartNow)
             Started = self.STARTED > 0
             CropStarted = Started & self.ricemask_BOOL
             self.STARTED = (
-                self.STARTED + CropStartNow_scalar + scalar(CropStarted)
-            ) * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
+                self.STARTED + CropStartNow_scalar + pcr.scalar(CropStarted)
+            ) * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
             print(
                 "Warning: using start date from ini file, not read from Crop Profile..."
             )
@@ -663,9 +664,9 @@ class WflowModel(DynamicModel):
                 CRPST_eq_STARTED = self.CRPST == self.STARTED
                 CropStartNow = CRPST_gt_0 & CRPST_eq_STARTED & self.ricemask_BOOL
                 CropStarted = Started & self.ricemask_BOOL
-                self.STARTED = (self.STARTED + self.CRPST) * ifthenelse(
-                    CropHarvNow, scalar(0.0), 1.0
-                )  # - ifthenelse(CropHarvNow, self.STARTED, 0.)
+                self.STARTED = (self.STARTED + self.CRPST) * pcr.ifthenelse(
+                    CropHarvNow, pcr.scalar(0.0), 1.0
+                )  # - pcr.ifthenelse(CropHarvNow, self.STARTED, 0.)
 
             elif self.AutoStartStop == True:
                 if self.HarvestDAP == 0:
@@ -680,7 +681,7 @@ class WflowModel(DynamicModel):
                 CropStartNow_Season1 = Time2Plant1stCrop & self.ricemask_BOOL
                 CropStartNow_Season2 = StdMin1 & self.ricemask_BOOL
                 CropStartNow = CropStartNow_Season1 | CropStartNow_Season2
-                CropStartNow_scalar = scalar(CropStartNow)
+                CropStartNow_scalar = pcr.scalar(CropStartNow)
                 if self.Sim3rdSeason == False:
                     HarvSeason1_temp = FirstSeason & CropHarvNow
                     HarvSeasonOne = HarvSeason1_temp & self.ricemask_BOOL
@@ -688,19 +689,19 @@ class WflowModel(DynamicModel):
                     HarvSeasonTwo = HarvSeason2_temp & self.ricemask_BOOL
                     self.Season = (
                         self.Season
-                        + ifthenelse(HarvSeasonOne, self.ricemask, 0.0)
-                        - ifthenelse(HarvSeasonTwo, self.ricemask * 2.0, 0.0)
+                        + pcr.ifthenelse(HarvSeasonOne, self.ricemask, 0.0)
+                        - pcr.ifthenelse(HarvSeasonTwo, self.ricemask * 2.0, 0.0)
                     )  # beware, this variable is also modified in another equation
                     Started = self.STARTED > 0
                     CropStarted = Started & self.ricemask_BOOL
                     SeasonOneHarvd = self.STARTED < 0
-                    SeasonOneHarvd_Scalar = scalar(SeasonOneHarvd)
-                    PrepareField_temp = scalar(self.Pausedays)
-                    PrepareField = ifthenelse(FirstSeason, PrepareField_temp, 0.0)
+                    SeasonOneHarvd_Scalar = pcr.scalar(SeasonOneHarvd)
+                    PrepareField_temp = pcr.scalar(self.Pausedays)
+                    PrepareField = pcr.ifthenelse(FirstSeason, PrepareField_temp, 0.0)
                     self.STARTED = (
-                        (self.STARTED + CropStartNow_scalar + scalar(CropStarted))
-                        * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
-                        - ifthenelse(HarvSeasonOne, PrepareField, 0.0)
+                        (self.STARTED + CropStartNow_scalar + pcr.scalar(CropStarted))
+                        * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+                        - pcr.ifthenelse(HarvSeasonOne, PrepareField, 0.0)
                         + SeasonOneHarvd_Scalar
                     )
                 elif self.Sim3rdSeason == True:
@@ -711,22 +712,22 @@ class WflowModel(DynamicModel):
                     )
                     self.Season = (
                         self.Season
-                        + ifthenelse(HarvSeasonOneTwo, scalar(1.0), 0.0)
-                        - ifthenelse(HarvSeasonThree, scalar(3.0), 0.0)
+                        + pcr.ifthenelse(HarvSeasonOneTwo, pcr.scalar(1.0), 0.0)
+                        - pcr.ifthenelse(HarvSeasonThree, pcr.scalar(3.0), 0.0)
                     )  # beware, this variable is also modified in another equation
                     Started = self.STARTED > 0
                     CropStarted = Started & self.ricemask_BOOL
                     Season12Harvd = self.STARTED < 0
-                    Season12Harvd_Scalar = scalar(Season12Harvd)
-                    PrepareField_temp = scalar(self.Pausedays)
+                    Season12Harvd_Scalar = pcr.scalar(Season12Harvd)
+                    PrepareField_temp = pcr.scalar(self.Pausedays)
                     FirstorSecondSeason = FirstSeason | SecondSeason
-                    PrepareField = ifthenelse(
+                    PrepareField = pcr.ifthenelse(
                         FirstorSecondSeason, PrepareField_temp, 0.0
                     )
                     self.STARTED = (
-                        (self.STARTED + CropStartNow_scalar + scalar(CropStarted))
-                        * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
-                        - ifthenelse(HarvSeasonOneTwo, PrepareField, 0.0)
+                        (self.STARTED + CropStartNow_scalar + pcr.scalar(CropStarted))
+                        * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+                        - pcr.ifthenelse(HarvSeasonOneTwo, PrepareField, 0.0)
                         + Season12Harvd_Scalar
                     )
                 else:
@@ -747,19 +748,19 @@ class WflowModel(DynamicModel):
         if self.WATERLIMITED == "True":
             TRANRF = self.Transpiration / NOTNUL_pcr(self.PotTrans)
             WAWP = WCWP * self.ROOTD_mm
-            Enough_water = ifthenelse(
+            Enough_water = pcr.ifthenelse(
                 CropStartNow, True, self.WA > WAWP
             )  # timestep delay...! todo
         else:
             print("Warning, run without water effects on crop growth...")
-            TRANRF = scalar(1.0)
+            TRANRF = pcr.scalar(1.0)
             Enough_water = True
 
         # self.T = (self.TMIN + self.TMAX)/2. # for testing with Wageningen weather files only - sdv
         # Calculate thermal time (for TSUM and DVS):
         Warm_Enough = self.T >= self.TBASE
         DegreeDay = self.T - self.TBASE
-        DTEFF = ifthenelse(Warm_Enough, DegreeDay, 0.0)
+        DTEFF = pcr.ifthenelse(Warm_Enough, DegreeDay, 0.0)
         # Check if leaves are present:
         Leaves_Present = self.LAI > 0.0
 
@@ -799,16 +800,16 @@ class WflowModel(DynamicModel):
         # Determine the influence of astronomical daylength on crop development (via thermal time - TSUM) by interpolation in the PHOTTB table
         PHOTT = self.PHOTTB.lookup_linear(DAYL)
         # Daylength only potentially has a  modifying influence on crop development (via thermal time, TSUM) before anthesis:
-        PHOTPF = ifthenelse(BeforeAnthesis, PHOTT, scalar(1.0))
+        PHOTPF = pcr.ifthenelse(BeforeAnthesis, PHOTT, pcr.scalar(1.0))
         # Influence (if any) of daylength results in a modified daily change in thermal time (TSUM).
         RTSUMP = DTEFF * PHOTPF
         # TSUM (state): at crop establishment TSUMI is added (the TSUM that was accumulated in the nursery in the case of transplanted rice);
         # during crop growth, the daily rate of change RTSUMP is added if EMERG = TRUE. Upon crop harvest, TSUM is reset (i.e. multiplied with 0.).
         self.TSUM = (
             self.TSUM
-            + ifthenelse(CropStartNow, scalar(self.TSUMI), 0.0)
-            + ifthenelse(EMERG, RTSUMP, 0.0)
-        ) * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
+            + pcr.ifthenelse(CropStartNow, pcr.scalar(self.TSUMI), 0.0)
+            + pcr.ifthenelse(EMERG, RTSUMP, 0.0)
+        ) * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
 
         # Calculation of DVS (state).
         # In LINTUL1 and LINTUL2, TSUM directly steered all processes influenced by crop phenological development.
@@ -816,11 +817,11 @@ class WflowModel(DynamicModel):
         # Hence in LINTUL3, some processes are still controlled directly by TSUM and some are controlled by its derived variable DVS
         # – a somewhat confusing situation that offers scope for future improvement.
         # After anthesis DVS proceeds at a different rate (DVS_gen) than before (DVS_veg). Throughout crop development DVS is calculated as the DVS_veg + DVS_gen.
-        DVS_veg = self.TSUM / self.TSUMAN * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
-        DVS_gen = (1.0 + (self.TSUM - self.TSUMAN) / self.TSUMMT) * ifthenelse(
-            CropHarvNow, scalar(0.0), 1.0
+        DVS_veg = self.TSUM / self.TSUMAN * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+        DVS_gen = (1.0 + (self.TSUM - self.TSUMAN) / self.TSUMMT) * pcr.ifthenelse(
+            CropHarvNow, pcr.scalar(0.0), 1.0
         )
-        self.DVS = ifthenelse(Vegetative, DVS_veg, 0.0) + ifthenelse(
+        self.DVS = pcr.ifthenelse(Vegetative, DVS_veg, 0.0) + pcr.ifthenelse(
             Generative, DVS_gen, 0.0
         )
 
@@ -829,14 +830,14 @@ class WflowModel(DynamicModel):
         # Root growth occurs before anthesis if there is crop growth (EMERG = TRUE), enough water (already in EMERG - todo) and the maximum rooting depth has not yet been reached.
         RootGrowth = Enough_water & BeforeAnthesis & EMERG & CanGrowDownward
         # If root growth occurs, it occurs at a fixed pace (mm/day):
-        RROOTD_mm = ifthenelse(RootGrowth, self.RRDMAX_mm, scalar(0.0))
+        RROOTD_mm = pcr.ifthenelse(RootGrowth, self.RRDMAX_mm, pcr.scalar(0.0))
         # Rooting depth (state): at crop establishment ROOTDI_mm is added (the rooting depth at transplanting); during crop growth, the daily rate of change
         # self.ROOTDI_mm is added. Upon crop harvest, rooting depth is reset (i.e. multiplied with 0.).
         self.ROOTD_mm = (
             self.ROOTD_mm
-            + ifthenelse(CropStartNow, self.ROOTDI_mm, scalar(0.0))
+            + pcr.ifthenelse(CropStartNow, self.ROOTDI_mm, pcr.scalar(0.0))
             + RROOTD_mm
-        ) * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
+        ) * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
         # By depth growth, roots explore deeper layers of soil that contain previously untapped water supplies, the assumption is.
         # In the case of irrigated rice, it seems reasonable to assume that those layers are saturated with water (WCST = volumetric soil water content at saturation).
         # The volume of additional water that becomes available to the crop is then equal to EXPLOR:
@@ -845,7 +846,7 @@ class WflowModel(DynamicModel):
         #############################################################################################################
         # Water Limitation: effects on partitioning
         # If TRANRF falls below 0.5, root growth is accelerated:
-        FRTMOD = max(1.0, 1.0 / (TRANRF + 0.5))
+        FRTMOD = pcr.max(1.0, 1.0 / (TRANRF + 0.5))
         FRT = FRTWET * FRTMOD
         # ... and shoot growth (i.e. growth of all aboveground parts) diminshed:
         FSHMOD = (1.0 - FRT) / (1 - FRT / FRTMOD)
@@ -856,97 +857,97 @@ class WflowModel(DynamicModel):
         # Daily intercepted Photosynthetically Active Radiation (PAR), according to (Lambert-)Beer's law.
         # The factor 0.5 accounts for the fact that about 50% (in terms of energy) of the frequency spectrum of incident solar radiation
         # can be utilized for photosynthesis by green plants.
-        PARINT = ifthenelse(
+        PARINT = pcr.ifthenelse(
             Not_Finished,
-            0.5 * self.IRRAD * 0.001 * (1.0 - exp(-self.K * self.LAI)),
+            0.5 * self.IRRAD * 0.001 * (1.0 - pcr.exp(-self.K * self.LAI)),
             0.0,
         )
         # The total growth rate is proportional to the intercepted PAR with a fixed Light Use Efficiency (LUE) - the core of the LINTUL apporach.
         GTOTAL = self.LUE * PARINT * TRANRF
 
         # Leaf dying due to ageing occurs from anthesis on (actually that is already arranged in the interpolation table - double!), with a relative death rate RDRTMP:
-        RDRDV = ifthenelse(AtAndAfterAnthesis, RDRTMP, scalar(0.0))
+        RDRDV = pcr.ifthenelse(AtAndAfterAnthesis, RDRTMP, pcr.scalar(0.0))
         # Leaf dying due to mutual shading occurs when LAI > LAICR:
-        RDRSH = max(0.0, self.RDRSHM * (self.LAI - self.LAICR) / self.LAICR)
+        RDRSH = pcr.max(0.0, self.RDRSHM * (self.LAI - self.LAICR) / self.LAICR)
         # The largest of the two effects determines the relative death rate of foliage:
-        RDR = max(RDRDV, RDRSH)
+        RDR = pcr.max(RDRDV, RDRSH)
 
         # Impact of leaf dying on leaf weight - N limitation stuff not (yet) implemented
         N_Limitation = NNI < 1.0
-        DLVNS = ifthenelse(CropStarted, scalar(1.0), 0.0) * ifthenelse(
+        DLVNS = pcr.ifthenelse(CropStarted, pcr.scalar(1.0), 0.0) * pcr.ifthenelse(
             N_Limitation, self.WLVG * self.RDRNS * (1.0 - NNI), 0.0
         )
         DLVS = self.WLVG * RDR
-        DLV = (DLVS + DLVNS) * scalar(Not_Finished)
-        RWLVG = ifthenelse(EMERG, GTOTAL * FLV - DLV, scalar(0.0))
+        DLV = (DLVS + DLVNS) * pcr.scalar(Not_Finished)
+        RWLVG = pcr.ifthenelse(EMERG, GTOTAL * FLV - DLV, pcr.scalar(0.0))
         self.WLVG = (
-            self.WLVG + ifthenelse(CropStartNow, self.WLVGI, scalar(0.0)) + RWLVG
-        ) * (1.0 - scalar(CropHarvNow))
-        self.WLVD = (self.WLVD + DLV) * (1.0 - scalar(CropHarvNow))
+            self.WLVG + pcr.ifthenelse(CropStartNow, self.WLVGI, pcr.scalar(0.0)) + RWLVG
+        ) * (1.0 - pcr.scalar(CropHarvNow))
+        self.WLVD = (self.WLVD + DLV) * (1.0 - pcr.scalar(CropHarvNow))
 
         # Growth of leaves in terms of mass (GLV) and in terms of LAI (GLAI).
         GLV = FLV * GTOTAL
         Adt_or_Harv = pcror(Adult, CropHarvNow)
         Juv_or_Harv = pcror(Juvenile, CropHarvNow)
         NoLeavesYet = self.LAI == 0.0
-        LetsGo = pcrand(Enough_water, CropStartNow)
-        LetsGro = pcrand(NoLeavesYet, LetsGo)
+        LetsGo = pcr.pcrand(Enough_water, CropStartNow)
+        LetsGro = pcr.pcrand(NoLeavesYet, LetsGo)
 
         GLAI = (
-            ifthenelse(Adt_or_Harv, SLA * GLV, scalar(0.0))
-            + ifthenelse(
+            pcr.ifthenelse(Adt_or_Harv, SLA * GLV, pcr.scalar(0.0))
+            + pcr.ifthenelse(
                 Juv_or_Harv,
                 self.LAI
-                * (exp(self.RGRL * DTEFF * DELT) - 1.0)
+                * (pcr.exp(self.RGRL * DTEFF * DELT) - 1.0)
                 / DELT
                 * TRANRF
-                * exp(-self.LAI * (1.0 - NNI)),
+                * pcr.exp(-self.LAI * (1.0 - NNI)),
                 0.0,
             )
-            + ifthenelse(LetsGro, self.LAII / DELT, scalar(0.0))
+            + pcr.ifthenelse(LetsGro, self.LAII / DELT, pcr.scalar(0.0))
         )
 
         # (Abs.) impact of leaf dying on LAI
         # Daily decrease in LAI due to dying of leaves (if any), due to aging and/or mutual shading:
         DLAIS = self.LAI * RDR
         # Daily decrease in LAI due to nitrogen shortage (presently non-functional):
-        DLAINS = ifthenelse(CropStarted, scalar(1.0), 0.0) * ifthenelse(
+        DLAINS = pcr.ifthenelse(CropStarted, pcr.scalar(1.0), 0.0) * pcr.ifthenelse(
             N_Limitation, DLVNS * SLA, 0.0
         )
         # Total daily decrease in LAI due to leaf death (aging, mutual shading, N shortage):
-        DLAI = (DLAIS + DLAINS) * scalar(Not_Finished)
+        DLAI = (DLAIS + DLAINS) * pcr.scalar(Not_Finished)
         # The initial LAI (LAII, transplanted rice) is added to GLAI at crop establishment, not in below state equation as done by Shibu et al. (2010).
-        self.LAI = (self.LAI + GLAI - DLAI) * ifthenelse(CropHarvNow, scalar(0.0), 1.0)
+        self.LAI = (self.LAI + GLAI - DLAI) * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
 
         # Daily death rate of roots: if self.DVS >= self.DVSDR, a fraction self.DRRT of the roots is dying every day:
-        DRRT = ifthenelse(Roots_Dying, self.WRT * self.RDRRT, scalar(0.0))
+        DRRT = pcr.ifthenelse(Roots_Dying, self.WRT * self.RDRRT, pcr.scalar(0.0))
         # Net daily change in root weight: if there is crop growth, this is equal to daily weight increase (GTOTAL * FRT) minus the daily decrease due to dying roots (if any).
-        RWRT = ifthenelse(EMERG, GTOTAL * FRT - DRRT, scalar(0.0))
+        RWRT = pcr.ifthenelse(EMERG, GTOTAL * FRT - DRRT, pcr.scalar(0.0))
         # Calculation of the root weight (state): when the crop is planted, the initial root weight WRTLI is added. After that, the net (daily) rate of change RWRT is added.
         # Upon crop harvest, RWRT is reset (i.e. multiplied with 0.)
         self.WRT = (
-            self.WRT + ifthenelse(CropStartNow, self.WRTLI, scalar(0.0)) + RWRT
-        ) * (1.0 - scalar(CropHarvNow))
+            self.WRT + pcr.ifthenelse(CropStartNow, self.WRTLI, pcr.scalar(0.0)) + RWRT
+        ) * (1.0 - pcr.scalar(CropHarvNow))
         # WDRT (state) is the total quantity of leaves that has died (mostly relevant for mass balance checking purposes). Simply calculated by adding the daily dying roots (if any);
         # (the variable is reset upon crop harvest).
-        self.WDRT = (self.WDRT + DRRT) * (1.0 - scalar(CropHarvNow))
+        self.WDRT = (self.WDRT + DRRT) * (1.0 - pcr.scalar(CropHarvNow))
 
         # Daily change in the weight of the storage organs (rice grains) is fraction FSO of the total growth rate (GTOTAL). FSO is determined by phenology and moisture stress
         # (which can modify the root/shoort ratio)
-        RWSO = ifthenelse(EMERG, GTOTAL * FSO, scalar(0.0))
+        RWSO = pcr.ifthenelse(EMERG, GTOTAL * FSO, pcr.scalar(0.0))
         # Weight of storage organs (state) is simply calculated by accumulating the daily growth RWSO. At crop harvest, it is reset to 0.
         self.WSO = (
-            self.WSO + ifthenelse(CropStartNow, self.WSOI, scalar(0.0)) + RWSO
-        ) * (1.0 - scalar(CropHarvNow))
+            self.WSO + pcr.ifthenelse(CropStartNow, self.WSOI, pcr.scalar(0.0)) + RWSO
+        ) * (1.0 - pcr.scalar(CropHarvNow))
         # WSO in tons/ha:
         WSOTHA = self.WSO / 100.0
 
         # Daily change in the weight of the stems is a fraction FST of the total growth rate (GTOTAL). FST is determined by phenology and moisture stress
-        RWST = ifthenelse(EMERG, GTOTAL * FST, scalar(0.0))
+        RWST = pcr.ifthenelse(EMERG, GTOTAL * FST, pcr.scalar(0.0))
         # Weight of storage organs (state) is simply calculated by accumulating the daily growth RWSO. At crop harvest, it is reset to 0.
         self.WST = (
-            self.WST + ifthenelse(CropHarvNow, self.WSTI, scalar(0.0)) + RWST
-        ) * (1.0 - scalar(CropHarvNow))
+            self.WST + pcr.ifthenelse(CropHarvNow, self.WSTI, pcr.scalar(0.0)) + RWST
+        ) * (1.0 - pcr.scalar(CropHarvNow))
 
         # An additional state, handy for testing purposes:
         self.Test += 1.0

--- a/wflow/wflow_lintul.py
+++ b/wflow/wflow_lintul.py
@@ -817,7 +817,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # Hence in LINTUL3, some processes are still controlled directly by TSUM and some are controlled by its derived variable DVS
         # – a somewhat confusing situation that offers scope for future improvement.
         # After anthesis DVS proceeds at a different rate (DVS_gen) than before (DVS_veg). Throughout crop development DVS is calculated as the DVS_veg + DVS_gen.
-        DVS_veg = self.TSUM / self.TSUMAN * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+        DVS_veg = (
+            self.TSUM / self.TSUMAN * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+        )
         DVS_gen = (1.0 + (self.TSUM - self.TSUMAN) / self.TSUMMT) * pcr.ifthenelse(
             CropHarvNow, pcr.scalar(0.0), 1.0
         )
@@ -881,7 +883,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         DLV = (DLVS + DLVNS) * pcr.scalar(Not_Finished)
         RWLVG = pcr.ifthenelse(EMERG, GTOTAL * FLV - DLV, pcr.scalar(0.0))
         self.WLVG = (
-            self.WLVG + pcr.ifthenelse(CropStartNow, self.WLVGI, pcr.scalar(0.0)) + RWLVG
+            self.WLVG
+            + pcr.ifthenelse(CropStartNow, self.WLVGI, pcr.scalar(0.0))
+            + RWLVG
         ) * (1.0 - pcr.scalar(CropHarvNow))
         self.WLVD = (self.WLVD + DLV) * (1.0 - pcr.scalar(CropHarvNow))
 
@@ -917,7 +921,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # Total daily decrease in LAI due to leaf death (aging, mutual shading, N shortage):
         DLAI = (DLAIS + DLAINS) * pcr.scalar(Not_Finished)
         # The initial LAI (LAII, transplanted rice) is added to GLAI at crop establishment, not in below state equation as done by Shibu et al. (2010).
-        self.LAI = (self.LAI + GLAI - DLAI) * pcr.ifthenelse(CropHarvNow, pcr.scalar(0.0), 1.0)
+        self.LAI = (self.LAI + GLAI - DLAI) * pcr.ifthenelse(
+            CropHarvNow, pcr.scalar(0.0), 1.0
+        )
 
         # Daily death rate of roots: if self.DVS >= self.DVSDR, a fraction self.DRRT of the roots is dying every day:
         DRRT = pcr.ifthenelse(Roots_Dying, self.WRT * self.RDRRT, pcr.scalar(0.0))

--- a/wflow/wflow_pcrglobwb.py
+++ b/wflow/wflow_pcrglobwb.py
@@ -85,21 +85,14 @@ usage
 
 """
 
-
-# import pcrut
-import sys
-import os
 import os.path
-import getopt
 
-
-from wflow.wf_DynamicFramework import *
-from wflow.wflow_funcs import *
-from wflow.wflow_adapt import *
-
-from wflow.pcrglobwb import landSurface
 from wflow.pcrglobwb import groundwater
+from wflow.pcrglobwb import landSurface
 from wflow.pcrglobwb import routing
+from wflow.wf_DynamicFramework import *
+from wflow.wflow_adapt import *
+from wflow.wflow_funcs import *
 
 wflow = "wflow_pcrglobwb: "
 

--- a/wflow/wflow_pcrglobwb.py
+++ b/wflow/wflow_pcrglobwb.py
@@ -87,6 +87,7 @@ usage
 
 import os.path
 
+import pcraster.framework
 from wflow.pcrglobwb import groundwater
 from wflow.pcrglobwb import landSurface
 from wflow.pcrglobwb import routing
@@ -256,7 +257,7 @@ def setLandSurfaceStates(landSurface):
             )
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
 
     """
   The user defined model class.
@@ -264,14 +265,14 @@ class WflowModel(DynamicModel):
   """
 
     def __init__(self, cloneMap, Dir, RunDir, configfile, staticmaps):
-        DynamicModel.__init__(self)
+        pcraster.framework.DynamicModel.__init__(self)
 
         self.caseName = os.path.abspath(Dir)
         self.runId = RunDir
         self.Dir = os.path.abspath(Dir)
         self.staticmaps = os.path.join(self.Dir, staticmaps)
         self.clonemappath = os.path.join(os.path.abspath(Dir), staticmaps, cloneMap)
-        setclone(self.clonemappath)
+        pcr.setclone(self.clonemappath)
         self.configfile = configfile
         self.SaveDir = os.path.join(self.Dir, self.runId)
 
@@ -518,7 +519,7 @@ class WflowModel(DynamicModel):
         wflow_landmask = self.wf_readmap(
             os.path.join(self.staticmaps, landmask), 0.0, fail=True
         )
-        wflow_ldd = ldd(
+        wflow_ldd = pcr.ldd(
             self.wf_readmap(os.path.join(self.staticmaps, lddMap), 0.0, fail=True)
         )
 

--- a/wflow/wflow_routing.py
+++ b/wflow/wflow_routing.py
@@ -59,16 +59,11 @@ usage
 
 """
 
-import numpy
-import os
 import os.path
-import getopt
-
 
 from wflow.wf_DynamicFramework import *
-from wflow.wflow_funcs import *
 from wflow.wflow_adapt import *
-
+from wflow.wflow_funcs import *
 
 wflow = "wflow_routing: "
 

--- a/wflow/wflow_routing.py
+++ b/wflow/wflow_routing.py
@@ -141,7 +141,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Qbankfull = pow(self.bankFull / self.AlphaCh * self.Bw, 1.0 / self.Beta)
         self.Qchannel = pcr.min(self.SurfaceRunoff, self.Qbankfull)
         self.floodcells = pcr.boolean(
-            pcr.ifthenelse(self.WaterLevelCH > self.bankFull, pcr.boolean(1), pcr.boolean(0))
+            pcr.ifthenelse(
+                self.WaterLevelCH > self.bankFull, pcr.boolean(1), pcr.boolean(0)
+            )
         )
         self.Qfloodplain = pcr.max(0.0, self.SurfaceRunoff - self.Qbankfull)
 
@@ -424,7 +426,10 @@ class WflowModel(pcraster.framework.DynamicModel):
             )
             self.TopoLddOrg = self.TopoLdd
             self.TopoLdd = pcr.lddrepair(
-                pcr.cover(pcr.ifthen(pcr.boolean(self.ReserVoirSimpleLocs), pcr.ldd(5)), self.TopoLdd)
+                pcr.cover(
+                    pcr.ifthen(pcr.boolean(self.ReserVoirSimpleLocs), pcr.ldd(5)),
+                    self.TopoLdd,
+                )
             )
         else:
             self.nrresSimple = 0
@@ -478,7 +483,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0)))
+            ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
@@ -521,7 +527,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
             ds = pcr.downstream(self.TopoLdd, self.TopoId)
             usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
+            self.TopoLdd = pcr.lddrepair(
+                pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd)
+            )
 
         self.QMMConv = self.timestepsecs / (
             self.reallength * self.reallength * 0.001
@@ -537,7 +545,9 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         # On Flat areas the Aspect function fails, fill in with average...
         self.Aspect = pcr.ifthenelse(
-            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
+            pcr.defined(self.Aspect),
+            self.Aspect,
+            pcr.areaaverage(self.Aspect, self.TopoId),
         )
 
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
@@ -883,7 +893,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                 ##########################################################################
                 MaxExtract = self.InflowKinWaveCell + self.OldInwater
                 self.SurfaceWaterSupply = pcr.ifthenelse(
-                    self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+                    self.Inflow < 0.0,
+                    pcr.min(MaxExtract, -1.0 * self.Inflow),
+                    self.ZeroMap,
                 )
                 # Fraction of demand that is not used but flows back into the river get fracttion and move to return locations
                 self.DemandReturnFlow = pcr.cover(
@@ -921,7 +933,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                     self.SurfaceRunoff * self.QMMConv
                 )  # SurfaceRunoffMM (mm) from SurfaceRunoff (m3/s)
 
-                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.OldSurfaceRunoff)
+                self.InflowKinWaveCell = pcr.upstream(
+                    self.TopoLdd, self.OldSurfaceRunoff
+                )
                 deltasup = float(pcr.mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
 
                 if deltasup < self.breakoff or self.nrit >= self.maxitsupply:
@@ -966,7 +980,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # first column (nr 1). Assumes that outputloc and columns match!
 
         if self.updating:
-            self.QM = pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            self.QM = (
+                pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            )
 
             # Now update the state. Just add to the Ustore
             # self.UStoreDepth =  result

--- a/wflow/wflow_sbm.py
+++ b/wflow/wflow_sbm.py
@@ -86,6 +86,9 @@ usage
 
 import os.path
 
+import numpy as np
+import pcraster as pcr
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 from wflow.wflow_funcs import *
@@ -110,7 +113,7 @@ def actEvap_sat_SBM(RootingDepth, WTable, FirstZoneDepth, PotTrans, smoothpar):
     # use sCurve to determine if the roots are wet.At the moment this ise set
     # to be a 0-1 curve
     wetroots = sCurve(WTable, a=RootingDepth, c=smoothpar)
-    ActEvapSat = min(PotTrans * wetroots, FirstZoneDepth)
+    ActEvapSat = pcr.min(PotTrans * wetroots, FirstZoneDepth)
 
     FirstZoneDepth = FirstZoneDepth - ActEvapSat
     RestPotEvap = PotTrans - ActEvapSat
@@ -159,10 +162,10 @@ def actEvap_unsat_SBM(
     if ust >= 1:
         AvailCap = UStoreDepth * 0.99
     else:
-        AvailCap = ifthenelse(
+        AvailCap = pcr.ifthenelse(
             layerIndex < zi_layer,
-            min(1.0, max(0.0, (RootingDepth - sumLayer) / UStoreLayerThickness)),
-            min(1.0, max(0.0, (RootingDepth - sumLayer) / (WTable + 1 - sumLayer))),
+            pcr.min(1.0, pcr.max(0.0, (RootingDepth - sumLayer) / UStoreLayerThickness)),
+            pcr.min(1.0, pcr.max(0.0, (RootingDepth - sumLayer) / (WTable + 1 - sumLayer))),
         )
 
     MaxExtr = AvailCap * UStoreDepth
@@ -182,38 +185,38 @@ def actEvap_unsat_SBM(
 
     # According to Brooks-Corey
     par_lambda = 2 / (c - 3)
-    L = cover(L, 0)
-    UStoreDepth = cover(UStoreDepth, 0)
-    vwc = ifthenelse(L > 0, UStoreDepth / L, 0)
-    vwc = ifthenelse(vwc > 0, vwc, 0.0000001)
+    L = pcr.cover(L, 0)
+    UStoreDepth = pcr.cover(UStoreDepth, 0)
+    vwc = pcr.ifthenelse(L > 0, UStoreDepth / L, 0)
+    vwc = pcr.ifthenelse(vwc > 0, vwc, 0.0000001)
     head = hb / (
         ((vwc) / (thetaS - thetaR)) ** (1 / par_lambda)
     )  # Note that in the original formula, thetaR is extracted from vwc, but thetaR is not part of the numerical vwc calculation
-    head = ifthenelse(head <= hb, 1, head)
-    head = cover(head, 0)
+    head = pcr.ifthenelse(head <= hb, 1, head)
+    head = pcr.cover(head, 0)
 
     # Transform h to a reduction coefficient value according to Feddes et al. (1978).
-    alpha = ifthenelse(
+    alpha = pcr.ifthenelse(
         head <= h1,
         0,
-        ifthenelse(
+        pcr.ifthenelse(
             head >= h4,
             0,
-            ifthenelse(
+            pcr.ifthenelse(
                 head < h2,
                 (head - h1) / (h2 - h1),
-                ifthenelse(head > h3, 1 - (head - h3) / (h4 - h3), 1),
+                pcr.ifthenelse(head > h3, 1 - (head - h3) / (h4 - h3), 1),
             ),
         ),
     )
 
     ActEvapUStore = (
-        ifthenelse(
-            layerIndex > zi_layer, ZeroMap, min(MaxExtr, RestPotEvap, UStoreDepth)
+        pcr.ifthenelse(
+            layerIndex > zi_layer, ZeroMap, pcr.min(MaxExtr, RestPotEvap, UStoreDepth)
         )
     ) * alpha
 
-    UStoreDepth = ifthenelse(
+    UStoreDepth = pcr.ifthenelse(
         layerIndex > zi_layer, maskLayer, UStoreDepth - ActEvapUStore
     )
 
@@ -241,13 +244,13 @@ def soilevap_SBM_unsat(
     SaturationDeficit = SoilWaterCapacity - SatWaterDepth
 
     # Linear reduction of soil moisture evaporation based on deficit
-    soilevap = ifthenelse(
+    soilevap = pcr.ifthenelse(
         len(UStoreLayerThickness) == 1,
-        PotTransSoil * min(1.0, SaturationDeficit / SoilWaterCapacity),
+        PotTransSoil * pcr.min(1.0, SaturationDeficit / SoilWaterCapacity),
         PotTransSoil
-        * min(
+        * pcr.min(
             1.0,
-            ifthenelse(
+            pcr.ifthenelse(
                 zi >= UStoreLayerThickness[0],
                 UStoreLayerDepth[0] / (UStoreLayerThickness[0] * (thetaS - thetaR)),
                 UStoreLayerDepth[0] / ((zi + 1.0) * (thetaS - thetaR)),
@@ -269,22 +272,22 @@ def soilevap_SBM_sat(PotTransSoil,zi,thetaS,thetaR,UStoreLayerThickness, UStoreL
     
     # In case water is ponding, zi is negative - Start with setting negative values 
     # to 0.0 to assure positive soilevap values
-    zi = ifthenelse(zi < 0.0, 0.0, zi)
+    zi = pcr.ifthenelse(zi < 0.0, 0.0, zi)
     
     # Calculate soilevap
-    soilevap_sat = ifthenelse(len(UStoreLayerThickness)==1, 0.0, PotTransSoil * min(1.0, ifthenelse(zi >= UStoreLayerThickness[0], 0.0, (UStoreLayerThickness[0] - zi)/UStoreLayerThickness[0])))
+    soilevap_sat = pcr.ifthenelse(len(UStoreLayerThickness)==1, 0.0, PotTransSoil * pcr.min(1.0, pcr.ifthenelse(zi >= UStoreLayerThickness[0], 0.0, (UStoreLayerThickness[0] - zi)/UStoreLayerThickness[0])))
     
     # Set soilevap to demand (soilevap_sat) or, if less than the demand, the depth
     # of the saturated water layer
-    soilevapsat = ifthenelse(len(UStoreLayerThickness)==1, 0.0, min(soilevap_sat, ifthenelse(zi >= UStoreLayerThickness[0], 0.0, (UStoreLayerThickness[0] - zi)*(thetaS-thetaR))))
+    soilevapsat = pcr.ifthenelse(len(UStoreLayerThickness)==1, 0.0, pcr.min(soilevap_sat, pcr.ifthenelse(zi >= UStoreLayerThickness[0], 0.0, (UStoreLayerThickness[0] - zi)*(thetaS-thetaR))))
     
     return soilevapsat
 
 
 def sum_UstoreLayerDepth(UStoreLayerThickness, ZeroMap, UStoreLayerDepth):
     sum_UstoreLayerDepth = ZeroMap
-    for n in arange(0, len(UStoreLayerThickness)):
-        sum_UstoreLayerDepth = sum_UstoreLayerDepth + cover(
+    for n in np.arange(0, len(UStoreLayerThickness)):
+        sum_UstoreLayerDepth = sum_UstoreLayerDepth + pcr.cover(
             UStoreLayerDepth[n], ZeroMap
         )
 
@@ -312,13 +315,13 @@ def SnowPackHBV(Snow, SnowWater, Precipitation, Temperature, TTI, TT, TTM, Cfmax
     CFR = 0.05000  # refreeing efficiency constant in refreezing of freewater in snow
     SFCF = 1.0  # correction factor for snowfall
 
-    RainFrac = ifthenelse(
+    RainFrac = pcr.ifthenelse(
         1.0 * TTI == 0.0,
-        ifthenelse(Temperature <= TT, scalar(0.0), scalar(1.0)),
-        min((Temperature - (TT - TTI / 2)) / TTI, scalar(1.0)),
+        pcr.ifthenelse(Temperature <= TT, pcr.scalar(0.0), pcr.scalar(1.0)),
+        pcr.min((Temperature - (TT - TTI / 2)) / TTI, pcr.scalar(1.0)),
     )
-    RainFrac = max(
-        RainFrac, scalar(0.0)
+    RainFrac = pcr.max(
+        RainFrac, pcr.scalar(0.0)
     )  # fraction of precipitation which falls as rain
     SnowFrac = 1 - RainFrac  # fraction of precipitation which falls as snow
     Precipitation = (
@@ -327,24 +330,24 @@ def SnowPackHBV(Snow, SnowWater, Precipitation, Temperature, TTI, TT, TTM, Cfmax
 
     SnowFall = SnowFrac * Precipitation  # snowfall depth
     RainFall = RainFrac * Precipitation  # rainfall depth
-    PotSnowMelt = ifthenelse(
-        Temperature > TTM, Cfmax * (Temperature - TTM), scalar(0.0)
+    PotSnowMelt = pcr.ifthenelse(
+        Temperature > TTM, Cfmax * (Temperature - TTM), pcr.scalar(0.0)
     )  # Potential snow melt, based on temperature
-    PotRefreezing = ifthenelse(
+    PotRefreezing = pcr.ifthenelse(
         Temperature < TTM, Cfmax * CFR * (TTM - Temperature), 0.0
     )  # Potential refreezing, based on temperature
-    Refreezing = ifthenelse(
-        Temperature < TTM, min(PotRefreezing, SnowWater), 0.0
+    Refreezing = pcr.ifthenelse(
+        Temperature < TTM, pcr.min(PotRefreezing, SnowWater), 0.0
     )  # actual refreezing
     # No landuse correction here
-    SnowMelt = min(PotSnowMelt, Snow)  # actual snow melt
+    SnowMelt = pcr.min(PotSnowMelt, Snow)  # actual snow melt
     Snow = Snow + SnowFall + Refreezing - SnowMelt  # dry snow content
     SnowWater = SnowWater - Refreezing  # free water content in snow
     MaxSnowWater = Snow * WHC  # Max water in the snow
     SnowWater = (
         SnowWater + SnowMelt + RainFall
     )  # Add all water and potentially supersaturate the snowpack
-    RainFall = max(SnowWater - MaxSnowWater, 0.0)  # rain + surpluss snowwater
+    RainFall = pcr.max(SnowWater - MaxSnowWater, 0.0)  # rain + surpluss snowwater
     SnowWater = SnowWater - RainFall
 
     return Snow, SnowWater, SnowMelt, RainFall, SnowFall
@@ -363,19 +366,19 @@ def GlacierMelt(GlacierStore, Snow, Temperature, TT, Cfmax):
     :returns: GlacierStore,GlacierMelt,
     """
 
-    PotMelt = ifthenelse(
-        Temperature > TT, Cfmax * (Temperature - TT), scalar(0.0)
+    PotMelt = pcr.ifthenelse(
+        Temperature > TT, Cfmax * (Temperature - TT), pcr.scalar(0.0)
     )  # Potential snow melt, based on temperature
 
-    GlacierMelt = ifthenelse(
-        Snow > 10.0, min(PotMelt, GlacierStore), cover(0.0)
+    GlacierMelt = pcr.ifthenelse(
+        Snow > 10.0, pcr.min(PotMelt, GlacierStore), pcr.cover(0.0)
     )  # actual Glacier melt
     GlacierStore = GlacierStore - GlacierMelt  # dry snow content
 
     return GlacierStore, GlacierMelt
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
     .. versionchanged:: 0.91
         - Calculation of GWScale moved to resume() to allow fitting.
@@ -388,12 +391,12 @@ class WflowModel(DynamicModel):
   """
 
     def __init__(self, cloneMap, Dir, RunDir, configfile):
-        DynamicModel.__init__(self)
+        pcraster.framework.DynamicModel.__init__(self)
 
         self.UStoreLayerDepth = []
         self.caseName = os.path.abspath(Dir)
         self.clonemappath = os.path.join(os.path.abspath(Dir), "staticmaps", cloneMap)
-        setclone(self.clonemappath)
+        pcr.setclone(self.clonemappath)
         self.runId = RunDir
         self.Dir = os.path.abspath(Dir)
         self.configfile = configfile
@@ -411,9 +414,9 @@ class WflowModel(DynamicModel):
         :return: demand
         """
 
-        Et_diff = areaaverage(pottrans - acttrans, nominal(irareas))
+        Et_diff = pcr.areaaverage(pottrans - acttrans, pcr.nominal(irareas))
         # Now determine demand in m^3/s for each area
-        sqmarea = areatotal(self.reallength * self.reallength, nominal(irareas))
+        sqmarea = pcr.areatotal(self.reallength * self.reallength, pcr.nominal(irareas))
         m3sec = Et_diff * sqmarea / 1000.0 / self.timestepsecs
 
         return Et_diff, m3sec
@@ -683,10 +686,10 @@ class WflowModel(DynamicModel):
         global multpars
         global updateCols
 
-        self.thestep = scalar(0)
+        self.thestep = pcr.scalar(0)
         self.basetimestep = 86400
         self.SSSF = False
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
         self.logger.info("running for " + str(self.nrTimeSteps()) + " timesteps")
 
@@ -789,28 +792,28 @@ class WflowModel(DynamicModel):
         )
 
         # 2: Input base maps ########################################################
-        subcatch = ordinal(
+        subcatch = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # Determines the area of calculations (all cells > 0)
-        subcatch = ifthen(subcatch > 0, subcatch)
+        subcatch = pcr.ifthen(subcatch > 0, subcatch)
 
         self.Altitude = self.wf_readmap(
             os.path.join(self.Dir, wflow_dem), 0.0, fail=True
-        )  # * scalar(defined(subcatch)) # DEM
-        self.TopoLdd = ldd(
+        )  # * pcr.scalar(pcr.defined(subcatch)) # DEM
+        self.TopoLdd = pcr.ldd(
             self.wf_readmap(os.path.join(self.Dir, wflow_ldd), 0.0, fail=True)
         )  # Local
-        self.TopoId = ordinal(
+        self.TopoId = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # area map
-        self.River = cover(
-            boolean(
+        self.River = pcr.cover(
+            pcr.boolean(
                 self.wf_readmap(os.path.join(self.Dir, wflow_river), 0.0, fail=True)
             ),
             0,
         )
 
-        self.RiverLength = cover(
+        self.RiverLength = pcr.cover(
             self.wf_readmap(os.path.join(self.Dir, wflow_riverlength), 0.0), 0.0
         )
         # Factor to multiply riverlength with (defaults to 1.0)
@@ -820,18 +823,18 @@ class WflowModel(DynamicModel):
 
         # read landuse and soilmap and make sure there are no missing points related to the
         # subcatchment map. Currently sets the lu and soil type  type to 1
-        self.LandUse = ordinal(
+        self.LandUse = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_landuse), 0.0, fail=True)
         )
-        self.LandUse = cover(self.LandUse, ordinal(subcatch > 0))
-        self.Soil = ordinal(
+        self.LandUse = pcr.cover(self.LandUse, pcr.ordinal(subcatch > 0))
+        self.Soil = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_soil), 0.0, fail=True)
         )
-        self.Soil = cover(self.Soil, ordinal(subcatch > 0))
-        self.OutputLoc = ordinal(
+        self.Soil = pcr.cover(self.Soil, pcr.ordinal(subcatch > 0))
+        self.OutputLoc = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_gauges), 0.0, fail=True)
         )  # location of output gauge(s)
-        self.InflowLoc = ordinal(
+        self.InflowLoc = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_inflow), 0.0)
         )  # location abstractions/inflows.
         self.RiverWidth = self.wf_readmap(os.path.join(self.Dir, wflow_riverwidth), 0.0)
@@ -842,7 +845,7 @@ class WflowModel(DynamicModel):
         self.SubCatchFlowOnly = int(
             configget(self.config, "model", "SubCatchFlowOnly", "0")
         )
-        self.OutputId = ordinal(
+        self.OutputId = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # location of subcatchment
         # Temperature correction poer cell to add
@@ -859,14 +862,14 @@ class WflowModel(DynamicModel):
             0.0,
         )
 
-        self.ZeroMap = 0.0 * scalar(subcatch)  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(subcatch)  # map with only zero's
 
         # Set static initial values here #########################################
         self.pi = 3.1416
         self.e = 2.7183
         self.SScale = 100.0
-        self.Latitude = ycoordinate(boolean(self.Altitude))
-        self.Longitude = xcoordinate(boolean(self.Altitude))
+        self.Latitude = pcr.ycoordinate(pcr.boolean(self.Altitude))
+        self.Longitude = pcr.xcoordinate(pcr.boolean(self.Altitude))
 
         # Read parameters NEW Method
         self.logger.info("Linking parameters to landuse, catchment and soil...")
@@ -908,7 +911,7 @@ class WflowModel(DynamicModel):
                 )
 
             self.Cmax = self.Sl * self.LAI + self.Swood
-            self.CanopyGapFraction = exp(-self.Kext * self.LAI)
+            self.CanopyGapFraction = pcr.exp(-self.Kext * self.LAI)
             # TODO: Add MAXLAI and CWf lookup
         else:
             self.Cmax = self.readtblDefault(
@@ -1078,13 +1081,13 @@ class WflowModel(DynamicModel):
         )
 
         # Check if we have irrigation areas
-        tt = pcr2numpy(self.IrrigationAreas, 0.0)
+        tt = pcr.pcr2numpy(self.IrrigationAreas, 0.0)
         self.nrirri = tt.max()
         # Check of we have paddy irrigation areas
-        tt = pcr2numpy(self.IrrigationPaddyAreas, 0.0)
+        tt = pcr.pcr2numpy(self.IrrigationPaddyAreas, 0.0)
         self.nrpaddyirri = tt.max()
 
-        self.Beta = scalar(0.6)  # For sheetflow
+        self.Beta = pcr.scalar(0.6)  # For sheetflow
 
         self.M = self.readtblDefault(
             self.Dir + "/" + self.intbl + "/M.tbl",
@@ -1182,7 +1185,7 @@ class WflowModel(DynamicModel):
                 / self.basetimestep
             )
 
-            self.cf_soil = min(
+            self.cf_soil = pcr.min(
                 0.99,
                 self.readtblDefault(
                     self.Dir + "/" + self.intbl + "/cf_soil.tbl",
@@ -1199,12 +1202,12 @@ class WflowModel(DynamicModel):
         self.xl, self.yl, self.reallength = pcrut.detRealCellLength(
             self.ZeroMap, sizeinmetres
         )
-        self.Slope = slope(self.Altitude)
-        # self.Slope=ifthen(boolean(self.TopoId),max(0.001,self.Slope*celllength()/self.reallength))
-        self.Slope = max(0.00001, self.Slope * celllength() / self.reallength)
-        Terrain_angle = scalar(atan(self.Slope))
+        self.Slope = pcr.slope(self.Altitude)
+        # self.Slope=pcr.ifthen(pcr.boolean(self.TopoId),pcr.max(0.001,self.Slope*celllength()/self.reallength))
+        self.Slope = pcr.max(0.00001, self.Slope * pcr.celllength() / self.reallength)
+        Terrain_angle = pcr.scalar(pcr.atan(self.Slope))
 
-        self.N = ifthenelse(self.River, self.NRiver, self.N)
+        self.N = pcr.ifthenelse(self.River, self.NRiver, self.N)
 
         if hasattr(self, "ReserVoirSimpleLocs") or hasattr(
             self, "ReserVoirComplexLocs"
@@ -1214,41 +1217,41 @@ class WflowModel(DynamicModel):
 
         if hasattr(self, "ReserVoirSimpleLocs"):
             # Check if we have simple and or complex reservoirs
-            tt_simple = pcr2numpy(self.ReserVoirSimpleLocs, 0.0)
+            tt_simple = pcr.pcr2numpy(self.ReserVoirSimpleLocs, 0.0)
             self.nrresSimple = tt_simple.max()
-            self.ReserVoirLocs = self.ReserVoirLocs + cover(
-                scalar(self.ReserVoirSimpleLocs)
+            self.ReserVoirLocs = self.ReserVoirLocs + pcr.cover(
+                pcr.scalar(self.ReserVoirSimpleLocs)
             )
             areamap = self.reallength * self.reallength
-            res_area = areatotal(spatial(areamap), self.ReservoirSimpleAreas)
+            res_area = pcr.areatotal(pcr.spatial(areamap), self.ReservoirSimpleAreas)
 
-            resarea_pnt = ifthen(boolean(self.ReserVoirSimpleLocs), res_area)
-            self.ResSimpleArea = ifthenelse(
-                cover(self.ResSimpleArea, scalar(0.0)) > 0,
+            resarea_pnt = pcr.ifthen(pcr.boolean(self.ReserVoirSimpleLocs), res_area)
+            self.ResSimpleArea = pcr.ifthenelse(
+                pcr.cover(self.ResSimpleArea, pcr.scalar(0.0)) > 0,
                 self.ResSimpleArea,
-                cover(resarea_pnt, scalar(0.0)),
+                pcr.cover(resarea_pnt, pcr.scalar(0.0)),
             )
-            self.filter_P_PET = ifthenelse(
-                boolean(cover(res_area, scalar(0.0))), res_area * 0.0, self.filter_P_PET
+            self.filter_P_PET = pcr.ifthenelse(
+                pcr.boolean(pcr.cover(res_area, pcr.scalar(0.0))), res_area * 0.0, self.filter_P_PET
             )
         else:
             self.nrresSimple = 0
 
         if hasattr(self, "ReserVoirComplexLocs"):
-            tt_complex = pcr2numpy(self.ReserVoirComplexLocs, 0.0)
+            tt_complex = pcr.pcr2numpy(self.ReserVoirComplexLocs, 0.0)
             self.nrresComplex = tt_complex.max()
-            self.ReserVoirLocs = self.ReserVoirLocs + cover(
-                scalar(self.ReserVoirComplexLocs)
+            self.ReserVoirLocs = self.ReserVoirLocs + pcr.cover(
+                pcr.scalar(self.ReserVoirComplexLocs)
             )
-            res_area = cover(scalar(self.ReservoirComplexAreas), 0.0)
-            self.filter_P_PET = ifthenelse(
+            res_area = pcr.cover(pcr.scalar(self.ReservoirComplexAreas), 0.0)
+            self.filter_P_PET = pcr.ifthenelse(
                 res_area > 0, res_area * 0.0, self.filter_P_PET
             )
 
             # read files
             self.sh = {}
-            res_ids = ifthen(self.ResStorFunc == 2, self.ReserVoirComplexLocs)
-            np_res_ids = pcr2numpy(res_ids, 0)
+            res_ids = pcr.ifthen(self.ResStorFunc == 2, self.ReserVoirComplexLocs)
+            np_res_ids = pcr.pcr2numpy(res_ids, 0)
             np_res_ids_u = np.unique(np_res_ids[nonzero(np_res_ids)])
             if np.size(np_res_ids_u) > 0:
                 for item in nditer(np_res_ids_u):
@@ -1261,8 +1264,8 @@ class WflowModel(DynamicModel):
                         + ".tbl"
                     )
             self.hq = {}
-            res_ids = ifthen(self.ResOutflowFunc == 1, self.ReserVoirComplexLocs)
-            np_res_ids = pcr2numpy(res_ids, 0)
+            res_ids = pcr.ifthen(self.ResOutflowFunc == 1, self.ReserVoirComplexLocs)
+            np_res_ids = pcr.pcr2numpy(res_ids, 0)
             np_res_ids_u = np.unique(np_res_ids[nonzero(np_res_ids)])
             if size(np_res_ids_u) > 0:
                 for item in nditer(np_res_ids_u):
@@ -1280,7 +1283,7 @@ class WflowModel(DynamicModel):
             self.nrresComplex = 0
 
         if (self.nrresSimple + self.nrresComplex) > 0:
-            self.ReserVoirLocs = ordinal(self.ReserVoirLocs)
+            self.ReserVoirLocs = pcr.ordinal(self.ReserVoirLocs)
             self.logger.info(
                 "A total of "
                 + str(self.nrresSimple)
@@ -1288,13 +1291,13 @@ class WflowModel(DynamicModel):
                 + str(self.nrresComplex)
                 + " complex reservoirs found."
             )
-            self.ReserVoirDownstreamLocs = downstream(self.TopoLdd, self.ReserVoirLocs)
+            self.ReserVoirDownstreamLocs = pcr.downstream(self.TopoLdd, self.ReserVoirLocs)
             self.TopoLddOrg = self.TopoLdd
-            self.TopoLdd = lddrepair(
-                cover(ifthen(boolean(self.ReserVoirLocs), ldd(5)), self.TopoLdd)
+            self.TopoLdd = pcr.lddrepair(
+                pcr.cover(pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)), self.TopoLdd)
             )
 
-            tt_filter = pcr2numpy(self.filter_P_PET, 1.0)
+            tt_filter = pcr.pcr2numpy(self.filter_P_PET, 1.0)
             self.filterResArea = tt_filter.min()
 
         # Determine river width from DEM, upstream area and yearly average discharge
@@ -1303,33 +1306,33 @@ class WflowModel(DynamicModel):
         # "Noah J. Finnegan et al 2005 Controls on the channel width of rivers:
         # Implications for modeling fluvial incision of bedrock"
 
-        upstr = catchmenttotal(1, self.TopoLdd)
-        Qscale = upstr / mapmaximum(upstr) * Qmax
+        upstr = pcr.catchmenttotal(1, self.TopoLdd)
+        Qscale = upstr / pcr.mapmaximum(upstr) * Qmax
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (max(0.0001, windowaverage(self.Slope, celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
-        self.RiverWidth = ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
+        self.RiverWidth = pcr.ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
 
         # Only allow reinfiltration in river cells by default
 
         if not hasattr(self, "MaxReinfilt"):
-            self.MaxReinfilt = ifthenelse(
+            self.MaxReinfilt = pcr.ifthenelse(
                 self.River, self.ZeroMap + 999.0, self.ZeroMap
             )
 
         # soil thickness based on topographical index (see Environmental modelling: finding simplicity in complexity)
         # 1: calculate wetness index
         # 2: Scale the capacity (now actually a max capacity) based on the index, also apply a minmum capacity
-        WI = ln(
-            accuflux(self.TopoLdd, 1) / self.Slope
+        WI = pcr.ln(
+            pcr.accuflux(self.TopoLdd, 1) / self.Slope
         )  # Topographical wetnesss. Scale WI by zone/subcatchment assuming these ara also geological units
-        WIMax = areamaximum(WI, self.TopoId) * WIMaxScale
-        self.SoilThickness = max(
-            min(self.SoilThickness, (WI / WIMax) * self.SoilThickness),
+        WIMax = pcr.areamaximum(WI, self.TopoId) * WIMaxScale
+        self.SoilThickness = pcr.max(
+            pcr.min(self.SoilThickness, (WI / WIMax) * self.SoilThickness),
             self.SoilMinThickness,
         )
 
@@ -1356,23 +1359,23 @@ class WflowModel(DynamicModel):
         self.SumThickness = self.ZeroMap
         self.nrLayersMap = self.ZeroMap
 
-        for n in arange(0, self.maxLayers):
+        for n in np.arange(0, self.maxLayers):
             self.SumLayer = self.SumThickness
             if self.USatLayers > 1 and n < self.USatLayers:
                 UstoreThick_temp = (
                     float(UStoreLayerThickness.split(",")[n]) + self.ZeroMap
                 )
-                UstoreThick = min(
-                    UstoreThick_temp, max(self.SoilThickness - self.SumLayer, 0.0)
+                UstoreThick = pcr.min(
+                    UstoreThick_temp, pcr.max(self.SoilThickness - self.SumLayer, 0.0)
                 )
             else:
-                UstoreThick_temp = mapmaximum(self.SoilThickness) - self.SumLayer
-                UstoreThick = min(
-                    UstoreThick_temp, max(self.SoilThickness - self.SumLayer, 0.0)
+                UstoreThick_temp = pcr.mapmaximum(self.SoilThickness) - self.SumLayer
+                UstoreThick = pcr.min(
+                    UstoreThick_temp, pcr.max(self.SoilThickness - self.SumLayer, 0.0)
                 )
 
             self.SumThickness = UstoreThick_temp + self.SumThickness
-            self.nrLayersMap = ifthenelse(
+            self.nrLayersMap = pcr.ifthenelse(
                 (self.SoilThickness >= self.SumThickness)
                 | (self.SoilThickness - self.SumLayer > self.ZeroMap),
                 self.nrLayersMap + 1,
@@ -1380,7 +1383,7 @@ class WflowModel(DynamicModel):
             )
 
             self.UStoreLayerThickness.append(
-                ifthenelse(
+                pcr.ifthenelse(
                     (self.SumThickness <= self.SoilThickness)
                     | (self.SoilThickness - self.SumLayer > self.ZeroMap),
                     UstoreThick,
@@ -1388,21 +1391,21 @@ class WflowModel(DynamicModel):
                 )
             )
             self.UStoreLayerDepth.append(
-                ifthen(
+                pcr.ifthen(
                     (self.SumThickness <= self.SoilThickness)
                     | (self.SoilThickness - self.SumLayer > self.ZeroMap),
                     self.SoilThickness * 0.0,
                 )
             )
             self.T.append(
-                ifthen(
+                pcr.ifthen(
                     (self.SumThickness <= self.SoilThickness)
                     | (self.SoilThickness - self.SumLayer > self.ZeroMap),
                     self.SoilThickness * 0.0,
                 )
             )
             self.maskLayer.append(
-                ifthen(
+                pcr.ifthen(
                     (self.SumThickness <= self.SoilThickness)
                     | (self.SoilThickness - self.SumLayer > self.ZeroMap),
                     self.SoilThickness * 0.0,
@@ -1411,7 +1414,7 @@ class WflowModel(DynamicModel):
 
         self.KsatVerFrac = []
         self.c = []
-        for n in arange(0, len(self.UStoreLayerThickness)):
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
             self.KsatVerFrac.append(
                 self.readtblLayersDefault(
                     self.Dir + "/" + self.intbl + "/KsatVerFrac.tbl",
@@ -1434,17 +1437,17 @@ class WflowModel(DynamicModel):
             )
 
         # limit roots to top 99% of first zone
-        self.RootingDepth = min(self.SoilThickness * 0.99, self.RootingDepth)
+        self.RootingDepth = pcr.min(self.SoilThickness * 0.99, self.RootingDepth)
 
         # subgrid runoff generation, determine CC (sharpness of S-Curve) for upper
         # en lower part and take average
-        self.DemMax = readmap(self.Dir + "/staticmaps/wflow_demmax")
-        self.DrainageBase = readmap(self.Dir + "/staticmaps/wflow_demmin")
-        self.CClow = min(
-            100.0, -ln(1.0 / 0.1 - 1) / min(-0.1, self.DrainageBase - self.Altitude)
+        self.DemMax = pcr.readmap(self.Dir + "/staticmaps/wflow_demmax")
+        self.DrainageBase = pcr.readmap(self.Dir + "/staticmaps/wflow_demmin")
+        self.CClow = pcr.min(
+            100.0, -pcr.ln(1.0 / 0.1 - 1) / pcr.min(-0.1, self.DrainageBase - self.Altitude)
         )
-        self.CCup = min(
-            100.0, -ln(1.0 / 0.1 - 1) / min(-0.1, self.Altitude - self.DemMax)
+        self.CCup = pcr.min(
+            100.0, -pcr.ln(1.0 / 0.1 - 1) / pcr.min(-0.1, self.Altitude - self.DemMax)
         )
         self.CC = (self.CClow + self.CCup) * 0.5
 
@@ -1452,22 +1455,22 @@ class WflowModel(DynamicModel):
         self.UpdateMap = self.ZeroMap
 
         if self.updating:
-            _tmp = pcr2numpy(self.OutputLoc, 0.0)
+            _tmp = pcr.pcr2numpy(self.OutputLoc, 0.0)
             gaugear = _tmp
-            touse = numpy.zeros(gaugear.shape, dtype="int")
+            touse = np.zeros(gaugear.shape, dtype="int")
 
             for thecol in updateCols:
                 idx = (gaugear == thecol).nonzero()
                 touse[idx] = thecol
 
-            self.UpdateMap = numpy2pcr(Nominal, touse, 0.0)
+            self.UpdateMap = pcr.numpy2pcr(pcr.Nominal, touse, 0.0)
             # Calculate distance to updating points (upstream) annd use to scale the correction
             # ldddist returns zero for cell at the gauges so add 1.0 tp result
-            self.DistToUpdPt = cover(
-                min(
-                    ldddist(self.TopoLdd, boolean(cover(self.UpdateMap, 0)), 1)
+            self.DistToUpdPt = pcr.cover(
+                pcr.min(
+                    pcr.ldddist(self.TopoLdd, pcr.boolean(pcr.cover(self.UpdateMap, 0)), 1)
                     * self.reallength
-                    / celllength(),
+                    / pcr.celllength(),
                     self.UpdMaxDist,
                 ),
                 self.UpdMaxDist,
@@ -1475,16 +1478,16 @@ class WflowModel(DynamicModel):
 
         # Initializing of variables
         self.logger.info("Initializing of model variables..")
-        self.TopoLdd = lddmask(self.TopoLdd, boolean(self.TopoId))
-        catchmentcells = maptotal(scalar(self.TopoId))
+        self.TopoLdd = pcr.lddmask(self.TopoLdd, pcr.boolean(self.TopoId))
+        catchmentcells = pcr.maptotal(pcr.scalar(self.TopoId))
 
         # Limit lateral flow per subcatchment (make pits at all subcatch boundaries)
         # This is very handy for Ribasim etc...
         if self.SubCatchFlowOnly > 0:
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
-            ds = downstream(self.TopoLdd, self.TopoId)
-            usid = ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = lddrepair(ifthenelse(boolean(usid), ldd(5), self.TopoLdd))
+            ds = pcr.downstream(self.TopoLdd, self.TopoId)
+            usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
+            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
 
         # Used to seperate output per LandUse/management classes
         OutZones = self.LandUse
@@ -1492,15 +1495,15 @@ class WflowModel(DynamicModel):
         self.QMMConv = self.timestepsecs / (
             self.reallength * self.reallength * 0.001
         )  # m3/s --> actial mm of water over the cell
-        # self.QMMConvUp = 1000.0 * self.timestepsecs / ( catchmenttotal(cover(1.0), self.TopoLdd) * self.reallength * self.reallength)  #m3/s --> mm over upstreams
+        # self.QMMConvUp = 1000.0 * self.timestepsecs / ( pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd) * self.reallength * self.reallength)  #m3/s --> mm over upstreams
         temp = (
-            catchmenttotal(cover(1.0), self.TopoLdd)
+            pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
             * self.reallength
             * 0.001
             * 0.001
             * self.reallength
         )
-        self.QMMConvUp = cover(self.timestepsecs * 0.001) / temp
+        self.QMMConvUp = pcr.cover(self.timestepsecs * 0.001) / temp
         self.ToCubic = (
             self.reallength * self.reallength * 0.001
         ) / self.timestepsecs  # m3/s
@@ -1538,19 +1541,19 @@ class WflowModel(DynamicModel):
         self.CumIF = self.ZeroMap
         self.CumActInfilt = self.ZeroMap
         self.IRSupplymm = self.ZeroMap
-        self.Aspect = scalar(aspect(self.Altitude))  # aspect [deg]
-        self.Aspect = ifthenelse(self.Aspect <= 0.0, scalar(0.001), self.Aspect)
+        self.Aspect = pcr.scalar(pcr.aspect(self.Altitude))  # aspect [deg]
+        self.Aspect = pcr.ifthenelse(self.Aspect <= 0.0, pcr.scalar(0.001), self.Aspect)
         # On Flat areas the Aspect function fails, fill in with average...
-        self.Aspect = ifthenelse(
-            defined(self.Aspect), self.Aspect, areaaverage(self.Aspect, self.TopoId)
+        self.Aspect = pcr.ifthenelse(
+            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
         )
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
         drainlength = detdrainlength(self.TopoLdd, self.xl, self.yl)
 
         # Multiply with Factor (taken from upscaling operation, defaults to 1.0 if no map is supplied
-        self.DCL = drainlength * max(1.0, self.RiverLengthFac)
+        self.DCL = drainlength * pcr.max(1.0, self.RiverLengthFac)
 
-        self.DCL = max(self.DCL, self.RiverLength)  # m
+        self.DCL = pcr.max(self.DCL, self.RiverLength)  # m
 
         # water depth (m)
         # set width for kinematic wave to cell width for all cells
@@ -1558,29 +1561,29 @@ class WflowModel(DynamicModel):
         # However, in the main river we have real flow so set the width to the
         # width of the river
 
-        self.Bw = ifthenelse(self.River, self.RiverWidth, self.Bw)
+        self.Bw = pcr.ifthenelse(self.River, self.RiverWidth, self.Bw)
 
         # Add rivers to the WaterFrac, but check with waterfrac map and correct
-        self.RiverFrac = min(
+        self.RiverFrac = pcr.min(
             1.0,
-            ifthenelse(
+            pcr.ifthenelse(
                 self.River, (self.RiverWidth * self.DCL) / (self.xl * self.yl), 0
             ),
         )
-        self.WaterFrac = min(1.0, self.WaterFrac + self.RiverFrac)
+        self.WaterFrac = pcr.min(1.0, self.WaterFrac + self.RiverFrac)
 
         # term for Alpha
         # Correct slope for extra length of the river in a gridcel
         riverslopecor = drainlength / self.DCL
-        # report(riverslopecor,"cor.map")
-        # report(self.Slope * riverslopecor,"slope.map")
-        self.AlpTerm = pow((self.N / (sqrt(self.Slope * riverslopecor))), self.Beta)
+        # pcr.report(riverslopecor,"cor.map")
+        # pcr.report(self.Slope * riverslopecor,"slope.map")
+        self.AlpTerm = pow((self.N / (pcr.sqrt(self.Slope * riverslopecor))), self.Beta)
         # power for Alpha
         self.AlpPow = (2.0 / 3.0) * self.Beta
         # initial approximation for Alpha
         # calculate catchmentsize
-        self.upsize = catchmenttotal(self.xl * self.yl, self.TopoLdd)
-        self.csize = areamaximum(self.upsize, self.TopoId)
+        self.upsize = pcr.catchmenttotal(self.xl * self.yl, self.TopoLdd)
+        self.csize = pcr.areamaximum(self.upsize, self.TopoId)
         self.wf_multparameters()
         # Save some summary maps
         self.logger.info("Saving summary maps...")
@@ -1636,7 +1639,7 @@ class WflowModel(DynamicModel):
             self.logger.info("Setting initial conditions to default")
             self.SatWaterDepth = self.SoilWaterCapacity * 0.85
 
-            # for n in arange(0,self.nrLayers):
+            # for n in np.arange(0,self.nrLayers):
             #    self.UStoreLayerDepth[n] = self.ZeroMap
             # TODO: move UStoreLayerDepth from initial to here
 
@@ -1649,7 +1652,7 @@ class WflowModel(DynamicModel):
             if hasattr(self, "ReserVoirSimpleLocs"):
                 self.ReservoirVolume = self.ResMaxVolume * self.ResTargetFullFrac
             if hasattr(self, "ReserVoirComplexLocs"):
-                self.ReservoirWaterLevel = cover(0.0)
+                self.ReservoirWaterLevel = pcr.cover(0.0)
             if hasattr(self, "GlacierFrac"):
                 self.GlacierStore = self.wf_readmap(
                     os.path.join(self.Dir, "staticmaps", "GlacierStore.map"),
@@ -1682,7 +1685,7 @@ class WflowModel(DynamicModel):
         )
 
         # Determine actual water depth
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )
         # TOPOG_SBM type soil stuff
@@ -1755,24 +1758,24 @@ class WflowModel(DynamicModel):
         # Read forcing data and dynamic parameters
 
         self.wf_updateparameters()
-        self.Precipitation = max(0.0, self.Precipitation)
+        self.Precipitation = pcr.max(0.0, self.Precipitation)
 
         # NB This may interfere with lintul link
         if hasattr(self, "LAI"):
             # Sl must also be defined
             ##TODO: add MAXLAI and CWf
             self.Cmax = self.Sl * self.LAI + self.Swood
-            self.CanopyGapFraction = exp(-self.Kext * self.LAI)
-            self.Ewet = (1 - exp(-self.Kext * self.LAI)) * self.PotenEvap
-            self.EoverR = ifthenelse(
+            self.CanopyGapFraction = pcr.exp(-self.Kext * self.LAI)
+            self.Ewet = (1 - pcr.exp(-self.Kext * self.LAI)) * self.PotenEvap
+            self.EoverR = pcr.ifthenelse(
                 self.Precipitation > 0.0,
-                min(0.25, cover(self.Ewet / max(0.0001, self.Precipitation), 0.0)),
+                pcr.min(0.25, pcr.cover(self.Ewet / pcr.max(0.0001, self.Precipitation), 0.0)),
                 0.0,
             )
             if hasattr(self, "MAXLAI") and hasattr(self, "CWf"):
                 # Adjust rootinggdepth
                 self.ActRootingDepth = self.CWf * (
-                    self.RootingDepth * self.LAI / max(0.001, self.MAXLAI)
+                    self.RootingDepth * self.LAI / pcr.max(0.001, self.MAXLAI)
                 ) + ((1 - self.CWf) * self.RootingDepth)
             else:
                 self.ActRootingDepth = self.RootingDepth
@@ -1819,17 +1822,17 @@ class WflowModel(DynamicModel):
             if self.MassWasting:
                 # Masswasting of dry snow
                 # 5.67 = tan 80 graden
-                SnowFluxFrac = min(0.5, self.Slope / 5.67) * min(
+                SnowFluxFrac = pcr.min(0.5, self.Slope / 5.67) * pcr.min(
                     1.0, self.Snow / MaxSnowPack
                 )
                 MaxFlux = SnowFluxFrac * self.Snow
-                self.Snow = accucapacitystate(self.TopoLdd, self.Snow, MaxFlux)
+                self.Snow = pcr.accucapacitystate(self.TopoLdd, self.Snow, MaxFlux)
             else:
                 SnowFluxFrac = self.ZeroMap
                 MaxFlux = self.ZeroMap
 
-            self.SnowCover = ifthenelse(self.Snow > 0, scalar(1), scalar(0))
-            self.NrCell = areatotal(self.SnowCover, self.TopoId)
+            self.SnowCover = pcr.ifthenelse(self.Snow > 0, pcr.scalar(1), pcr.scalar(0))
+            self.NrCell = pcr.areatotal(self.SnowCover, self.TopoId)
 
             if hasattr(self, "GlacierFrac"):
                 """
@@ -1839,16 +1842,16 @@ class WflowModel(DynamicModel):
                 """
                 # TODO: document glacier module
                 self.snowdist = sCurve(self.Snow, a=8300.0, c=0.06)
-                self.Snow2Glacier = ifthenelse(
+                self.Snow2Glacier = pcr.ifthenelse(
                     self.Snow > 8300, self.snowdist * (self.Snow - 8300), self.ZeroMap
                 )
 
-                self.Snow2Glacier = ifthenelse(
+                self.Snow2Glacier = pcr.ifthenelse(
                     self.GlacierFrac > 0.0, self.Snow2Glacier, self.ZeroMap
                 )
                 # Max conversion to 8mm/day
                 self.Snow2Glacier = (
-                    min(self.Snow2Glacier, 8.0) * self.timestepsecs / self.basetimestep
+                    pcr.min(self.Snow2Glacier, 8.0) * self.timestepsecs / self.basetimestep
                 )
 
                 self.Snow = self.Snow - (self.Snow2Glacier * self.GlacierFrac)
@@ -1881,8 +1884,8 @@ class WflowModel(DynamicModel):
                 maxevap=self.PotEvap,
             )
 
-            self.PotTransSoil = cover(
-                max(0.0, self.PotEvap - self.Interception), 0.0
+            self.PotTransSoil = pcr.cover(
+                pcr.max(0.0, self.PotEvap - self.Interception), 0.0
             )  # now in mm
 
         else:
@@ -1893,7 +1896,7 @@ class WflowModel(DynamicModel):
                 self.CanopyGapFraction,
                 self.Cmax,
             )
-            self.PotTransSoil = cover(max(0.0, LeftOver), 0.0)  # now in mm
+            self.PotTransSoil = pcr.cover(pcr.max(0.0, LeftOver), 0.0)  # now in mm
             self.Interception = NetInterception
 
         # Start with the soil calculations
@@ -1917,7 +1920,7 @@ class WflowModel(DynamicModel):
 
         # Runoff from water bodies and river network
         self.RunoffOpenWater = (
-            min(1.0, self.RiverFrac + self.WaterFrac) * self.AvailableForInfiltration
+            pcr.min(1.0, self.RiverFrac + self.WaterFrac) * self.AvailableForInfiltration
         )
         # self.RunoffOpenWater = self.ZeroMap
         self.AvailableForInfiltration = (
@@ -1929,7 +1932,7 @@ class WflowModel(DynamicModel):
             # Determine saturated fraction of cell
             self.SubCellFrac = sCurve(self.AbsoluteGW, c=self.CC, a=self.Altitude + 1.0)
             # Make sure total of SubCellFRac + WaterFRac + RiverFrac <=1 to avoid double counting
-            Frac_correction = ifthenelse(
+            Frac_correction = pcr.ifthenelse(
                 (self.SubCellFrac + self.RiverFrac + self.WaterFrac) > 1.0,
                 self.SubCellFrac + self.RiverFrac + self.WaterFrac - 1.0,
                 0.0,
@@ -1937,15 +1940,15 @@ class WflowModel(DynamicModel):
             self.SubCellRunoff = (
                 self.SubCellFrac - Frac_correction
             ) * self.AvailableForInfiltration
-            self.SubCellGWRunoff = min(
+            self.SubCellGWRunoff = pcr.min(
                 self.SubCellFrac * self.SatWaterDepth,
-                max(
+                pcr.max(
                     0.0,
                     self.SubCellFrac
                     * self.Slope
                     * self.KsatVer
                     * self.KsatHorFrac
-                    * exp(-self.f * self.zi),
+                    * pcr.exp(-self.f * self.zi),
                 ),
             )
             self.SatWaterDepth = self.SatWaterDepth - self.SubCellGWRunoff
@@ -1954,9 +1957,9 @@ class WflowModel(DynamicModel):
             )
         else:
             self.AbsoluteGW = self.DemMax - (self.zi * self.GWScale)
-            self.SubCellFrac = spatial(scalar(0.0))
-            self.SubCellGWRunoff = spatial(scalar(0.0))
-            self.SubCellRunoff = spatial(scalar(0.0))
+            self.SubCellFrac = pcr.spatial(pcr.scalar(0.0))
+            self.SubCellGWRunoff = pcr.spatial(pcr.scalar(0.0))
+            self.SubCellRunoff = pcr.spatial(pcr.scalar(0.0))
 
         # First determine if the soil infiltration capacity can deal with the
         # amount of water
@@ -1968,17 +1971,17 @@ class WflowModel(DynamicModel):
             soilInfRedu = sCurve(self.TSoil, a=self.ZeroMap, b=bb, c=8.0) + self.cf_soil
         else:
             soilInfRedu = 1.0
-        MaxInfiltSoil = min(self.InfiltCapSoil * soilInfRedu, SoilInf)
-        self.SoilInfiltExceeded = self.SoilInfiltExceeded + scalar(
+        MaxInfiltSoil = pcr.min(self.InfiltCapSoil * soilInfRedu, SoilInf)
+        self.SoilInfiltExceeded = self.SoilInfiltExceeded + pcr.scalar(
             self.InfiltCapSoil * soilInfRedu < SoilInf
         )
 
-        MaxInfiltPath = min(self.InfiltCapPath * soilInfRedu, PathInf)
-        self.PathInfiltExceeded = self.PathInfiltExceeded + scalar(
+        MaxInfiltPath = pcr.min(self.InfiltCapPath * soilInfRedu, PathInf)
+        self.PathInfiltExceeded = self.PathInfiltExceeded + pcr.scalar(
             self.InfiltCapPath * soilInfRedu < PathInf
         )
 
-        InfiltSoilPath = min(MaxInfiltPath + MaxInfiltSoil, max(0.0, UStoreCapacity))
+        InfiltSoilPath = pcr.min(MaxInfiltPath + MaxInfiltSoil, pcr.max(0.0, UStoreCapacity))
         self.In = InfiltSoilPath
         self.ActInfilt = InfiltSoilPath  # JS Ad this to be compatible with rest
 
@@ -1986,11 +1989,11 @@ class WflowModel(DynamicModel):
         self.ZiLayer = self.ZeroMap
 
         # Limit rootingdepth (if set externally)
-        self.ActRootingDepth = min(self.SoilThickness * 0.99, self.ActRootingDepth)
+        self.ActRootingDepth = pcr.min(self.SoilThickness * 0.99, self.ActRootingDepth)
 
         # Determine Open Water EVAP based on waterfrac. Later subtract this from water that
         # enters the Kinematic wave
-        self.ActEvapOpenWater = min(
+        self.ActEvapOpenWater = pcr.min(
             self.WaterLevel * 1000.0 * self.WaterFrac,
             self.WaterFrac * self.PotTransSoil,
         )
@@ -1999,17 +2002,17 @@ class WflowModel(DynamicModel):
 
         self.ActEvapPond = self.ZeroMap
         if self.nrpaddyirri > 0:
-            self.ActEvapPond = min(self.PondingDepth, self.RestEvap)
+            self.ActEvapPond = pcr.min(self.PondingDepth, self.RestEvap)
             self.PondingDepth = self.PondingDepth - self.ActEvapPond
             self.RestEvap = self.RestEvap - self.ActEvapPond
 
         # Go from top to bottom layer
         self.zi_t = self.zi
-        for n in arange(0, len(self.UStoreLayerThickness)):
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
             # Find layer with  zi level
-            self.ZiLayer = ifthenelse(
+            self.ZiLayer = pcr.ifthenelse(
                 self.zi > self.SumThickness,
-                min(self.ZeroMap + float(n), self.nrLayersMap - 1),
+                pcr.min(self.ZeroMap + float(n), self.nrLayersMap - 1),
                 self.ZiLayer,
             )
 
@@ -2026,22 +2029,22 @@ class WflowModel(DynamicModel):
         l_Thickness = []
         self.storage = []
         l_T = []
-        for n in arange(0, len(self.UStoreLayerThickness)):
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
             l_T.append(self.SumThickness)
             self.SumLayer = self.SumThickness
             self.SumThickness = self.UStoreLayerThickness[n] + self.SumThickness
 
             l_Thickness.append(self.SumThickness)
             # Height of unsat zone in layer n
-            self.L = ifthenelse(
+            self.L = pcr.ifthenelse(
                 self.ZiLayer == float(n),
-                ifthenelse(
+                pcr.ifthenelse(
                     self.ZeroMap + float(n) > 0, self.zi - l_Thickness[n - 1], self.zi
                 ),
                 self.UStoreLayerThickness[n],
             )
             # Depth for calculation of vertical fluxes (bottom layer or zi)
-            self.z = ifthenelse(self.ZiLayer == float(n), self.zi, self.SumThickness)
+            self.z = pcr.ifthenelse(self.ZiLayer == float(n), self.zi, self.SumThickness)
             self.storage.append(self.L * (self.thetaS - self.thetaR))
 
             # First layer is treated differently than layers below first layer
@@ -2061,13 +2064,13 @@ class WflowModel(DynamicModel):
                 )
                 # assume soil evaporation is from first soil layer
                 if self.nrpaddyirri > 0:
-                    self.soilevapunsat = ifthenelse(
+                    self.soilevapunsat = pcr.ifthenelse(
                         self.PondingDepth > 0.0,
                         0.0,
-                        min(self.soilevapunsat, self.UStoreLayerDepth[0]),
+                        pcr.min(self.soilevapunsat, self.UStoreLayerDepth[0]),
                     )
                 else:
-                    self.soilevapunsat = min(self.soilevapunsat, self.UStoreLayerDepth[n])
+                    self.soilevapunsat = pcr.min(self.soilevapunsat, self.UStoreLayerDepth[n])
 
                 # The remaining 'RestEvap' can be used for evaporation from the saturated layer
                 self.RestEvap = self.RestEvap - self.soilevapunsat
@@ -2116,8 +2119,8 @@ class WflowModel(DynamicModel):
                     st = (
                         self.KsatVerFrac[n]
                         * self.KsatVer
-                        * exp(-self.f * self.z)
-                        * min(
+                        * pcr.exp(-self.f * self.z)
+                        * pcr.min(
                             (
                                 (
                                     self.UStoreLayerDepth[n]
@@ -2128,17 +2131,17 @@ class WflowModel(DynamicModel):
                             1.0,
                         )
                     )
-                    self.T[n] = ifthenelse(
+                    self.T[n] = pcr.ifthenelse(
                         self.SaturationDeficit <= 0.00001,
                         0.0,
-                        min(self.UStoreLayerDepth[n], st),
+                        pcr.min(self.UStoreLayerDepth[n], st),
                     )
-                    self.T[n] = ifthenelse(
+                    self.T[n] = pcr.ifthenelse(
                         self.ZiLayer == float(n), self.maskLayer[n], self.T[n]
                     )
                     self.UStoreLayerDepth[n] = self.UStoreLayerDepth[n] - self.T[n]
             else:
-                self.UStoreLayerDepth[n] = ifthenelse(
+                self.UStoreLayerDepth[n] = pcr.ifthenelse(
                     self.ZiLayer < float(n),
                     self.maskLayer[n],
                     self.UStoreLayerDepth[n] + self.T[n - 1],
@@ -2166,8 +2169,8 @@ class WflowModel(DynamicModel):
                 st = (
                     self.KsatVerFrac[n]
                     * self.KsatVer
-                    * exp(-self.f * self.z)
-                    * min(
+                    * pcr.exp(-self.f * self.z)
+                    * pcr.min(
                         (
                             (
                                 self.UStoreLayerDepth[n]
@@ -2180,12 +2183,12 @@ class WflowModel(DynamicModel):
                 )
 
                 # Transfer in layer with zi is not yet substracted from layer (set to zero)
-                self.T[n] = ifthenelse(
+                self.T[n] = pcr.ifthenelse(
                     self.ZiLayer <= float(n),
                     self.maskLayer[n],
-                    min(self.UStoreLayerDepth[n], st),
+                    pcr.min(self.UStoreLayerDepth[n], st),
                 )
-                self.UStoreLayerDepth[n] = ifthenelse(
+                self.UStoreLayerDepth[n] = pcr.ifthenelse(
                     self.ZiLayer < float(n),
                     self.maskLayer[n],
                     self.UStoreLayerDepth[n] - self.T[n],
@@ -2217,7 +2220,7 @@ class WflowModel(DynamicModel):
             else:
                 IRDemand = self.IrriDemandExternal
             # loop over irrigation areas and assign Q to linked river extraction points
-            self.Inflow = cover(IRDemand, self.Inflow)
+            self.Inflow = pcr.cover(IRDemand, self.Inflow)
 
         ##########################################################################
         # Transfer of water from unsaturated to saturated store...################
@@ -2233,40 +2236,40 @@ class WflowModel(DynamicModel):
         self.SaturationDeficit = self.SoilWaterCapacity - self.SatWaterDepth
 
         Ksat = self.ZeroMap
-        for n in arange(0, len(self.UStoreLayerThickness)):
-            Ksat = Ksat + ifthenelse(
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
+            Ksat = Ksat + pcr.ifthenelse(
                 self.ZiLayer == float(n),
-                self.KsatVerFrac[n] * self.KsatVer * exp(-self.f * self.zi),
+                self.KsatVerFrac[n] * self.KsatVer * pcr.exp(-self.f * self.zi),
                 0.0,
             )
 
-        self.DeepKsat = self.KsatVer * exp(-self.f * self.SoilThickness)
+        self.DeepKsat = self.KsatVer * pcr.exp(-self.f * self.SoilThickness)
 
         # now the actual transfer to the saturated store from layers with zi
         self.Transfer = self.ZeroMap
-        for n in arange(0, len(self.UStoreLayerThickness)):
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
             if self.TransferMethod == 1:
-                self.L = ifthen(
+                self.L = pcr.ifthen(
                     self.ZiLayer == float(n),
-                    ifthenelse(
+                    pcr.ifthenelse(
                         self.ZeroMap + float(n) > 0,
                         self.zi - l_Thickness[n - 1],
                         self.zi,
                     ),
                 )
-                self.Transfer = self.Transfer + ifthenelse(
+                self.Transfer = self.Transfer + pcr.ifthenelse(
                     self.ZiLayer == float(n),
-                    min(
-                        cover(self.UStoreLayerDepth[n], 0.0),
-                        ifthenelse(
+                    pcr.min(
+                        pcr.cover(self.UStoreLayerDepth[n], 0.0),
+                        pcr.ifthenelse(
                             self.SaturationDeficit <= 0.00001,
                             0.0,
                             self.KsatVerFrac[n]
                             * self.KsatVer
-                            * exp(-self.f * self.zi)
+                            * pcr.exp(-self.f * self.zi)
                             * (
-                                min(
-                                    cover(self.UStoreLayerDepth[n], 0.0),
+                                pcr.min(
+                                    pcr.cover(self.UStoreLayerDepth[n], 0.0),
                                     (self.L + 0.0001) * (self.thetaS - self.thetaR),
                                 )
                             )
@@ -2277,19 +2280,19 @@ class WflowModel(DynamicModel):
                 )
 
             if self.TransferMethod == 2:
-                self.L = ifthen(
+                self.L = pcr.ifthen(
                     self.ZiLayer == float(n),
-                    ifthenelse(
+                    pcr.ifthenelse(
                         self.ZeroMap + float(n) > 0,
                         self.zi - l_Thickness[n - 1],
                         self.zi,
                     ),
                 )
-                st = ifthen(
+                st = pcr.ifthen(
                     self.ZiLayer == float(n),
                     self.KsatVer
-                    * exp(-self.f * self.zi)
-                    * min(
+                    * pcr.exp(-self.f * self.zi)
+                    * pcr.min(
                         (
                             self.UStoreLayerDepth[n]
                             / ((self.L + 0.0001) * (self.thetaS - self.thetaR))
@@ -2298,11 +2301,11 @@ class WflowModel(DynamicModel):
                     )
                     ** self.c[n],
                 )
-                self.Transfer = self.Transfer + ifthenelse(
+                self.Transfer = self.Transfer + pcr.ifthenelse(
                     self.ZiLayer == float(n),
-                    min(
+                    pcr.min(
                         self.UStoreLayerDepth[n],
-                        ifthenelse(self.SaturationDeficit <= 0.00001, 0.0, st),
+                        pcr.ifthenelse(self.SaturationDeficit <= 0.00001, 0.0, st),
                     ),
                     0.0,
                 )
@@ -2310,22 +2313,22 @@ class WflowModel(DynamicModel):
         # check soil moisture
         self.ToExtra = self.ZeroMap
 
-        for n in arange(len(self.UStoreLayerThickness) - 1, -1, -1):
-            # self.UStoreLayerDepth[n] = ifthenelse(self.ZiLayer<=n, self.UStoreLayerDepth[n] + self.ToExtra,self.UStoreLayerDepth[n])
-            diff = ifthenelse(
+        for n in np.arange(len(self.UStoreLayerThickness) - 1, -1, -1):
+            # self.UStoreLayerDepth[n] = pcr.ifthenelse(self.ZiLayer<=n, self.UStoreLayerDepth[n] + self.ToExtra,self.UStoreLayerDepth[n])
+            diff = pcr.ifthenelse(
                 self.ZiLayer == float(n),
-                max(
+                pcr.max(
                     0.0,
-                    (cover(self.UStoreLayerDepth[n], 0.0) - self.Transfer)
+                    (pcr.cover(self.UStoreLayerDepth[n], 0.0) - self.Transfer)
                     - self.storage[n],
                 ),
-                max(
+                pcr.max(
                     self.ZeroMap,
-                    cover(self.UStoreLayerDepth[n], 0.0)
-                    - ifthenelse(self.zi <= l_T[n], 0.0, self.storage[n]),
+                    pcr.cover(self.UStoreLayerDepth[n], 0.0)
+                    - pcr.ifthenelse(self.zi <= l_T[n], 0.0, self.storage[n]),
                 ),
             )
-            self.ToExtra = ifthenelse(diff > 0, diff, self.ZeroMap)
+            self.ToExtra = pcr.ifthenelse(diff > 0, diff, self.ZeroMap)
             self.UStoreLayerDepth[n] = self.UStoreLayerDepth[n] - diff
 
             if n > 0:
@@ -2333,7 +2336,7 @@ class WflowModel(DynamicModel):
                     self.UStoreLayerDepth[n - 1] + self.ToExtra
                 )
 
-            # self.UStoreLayerDepth[n] = ifthenelse(self.ZiLayer<=n, self.UStoreLayerDepth[n]-diff,self.UStoreLayerDepth[n])
+            # self.UStoreLayerDepth[n] = pcr.ifthenelse(self.ZiLayer<=n, self.UStoreLayerDepth[n]-diff,self.UStoreLayerDepth[n])
 
         SatFlow = self.ToExtra
         UStoreCapacity = (
@@ -2342,12 +2345,12 @@ class WflowModel(DynamicModel):
             - sum_list_cover(self.UStoreLayerDepth, self.ZeroMap)
         )
 
-        MaxCapFlux = max(
-            0.0, min(Ksat, self.ActEvapUStore, UStoreCapacity, self.SatWaterDepth)
+        MaxCapFlux = pcr.max(
+            0.0, pcr.min(Ksat, self.ActEvapUStore, UStoreCapacity, self.SatWaterDepth)
         )
 
         # No capilary flux is roots are in water, max flux if very near to water, lower flux if distance is large
-        CapFluxScale = ifthenelse(
+        CapFluxScale = pcr.ifthenelse(
             self.zi > self.ActRootingDepth,
             self.CapScale
             / (self.CapScale + self.zi - self.ActRootingDepth)
@@ -2361,43 +2364,43 @@ class WflowModel(DynamicModel):
         sumLayer = self.ZeroMap
 
         # Now add capflux to the layers one by one (from bottom to top)
-        for n in arange(len(self.UStoreLayerThickness) - 1, -1, -1):
+        for n in np.arange(len(self.UStoreLayerThickness) - 1, -1, -1):
 
-            L = ifthenelse(
+            L = pcr.ifthenelse(
                 self.ZiLayer == float(n),
-                ifthenelse(
+                pcr.ifthenelse(
                     self.ZeroMap + float(n) > 0, self.zi - l_Thickness[n - 1], self.zi
                 ),
                 self.UStoreLayerThickness[n],
             )
-            thisLayer = ifthenelse(
+            thisLayer = pcr.ifthenelse(
                 self.ZiLayer <= float(n),
-                min(
+                pcr.min(
                     ToAdd,
-                    max(
+                    pcr.max(
                         L * (self.thetaS - self.thetaR) - self.UStoreLayerDepth[n], 0.0
                     ),
                 ),
                 0.0,
             )
-            self.UStoreLayerDepth[n] = ifthenelse(
+            self.UStoreLayerDepth[n] = pcr.ifthenelse(
                 self.ZiLayer <= float(n),
                 self.UStoreLayerDepth[n] + thisLayer,
                 self.UStoreLayerDepth[n],
             )
-            ToAdd = ToAdd - cover(thisLayer, 0.0)
-            sumLayer = sumLayer + cover(thisLayer, 0.0)
+            ToAdd = ToAdd - pcr.cover(thisLayer, 0.0)
+            sumLayer = sumLayer + pcr.cover(thisLayer, 0.0)
 
         # Determine Ksat at base
-        self.DeepTransfer = min(self.SatWaterDepth, self.DeepKsat)
+        self.DeepTransfer = pcr.min(self.SatWaterDepth, self.DeepKsat)
         # ActLeakage = 0.0
         # Now add leakage. to deeper groundwater
-        self.ActLeakage = cover(max(0.0, min(self.MaxLeakage, self.DeepTransfer)), 0)
-        self.Percolation = cover(
-            max(0.0, min(self.MaxPercolation, self.DeepTransfer)), 0
+        self.ActLeakage = pcr.cover(pcr.max(0.0, pcr.min(self.MaxLeakage, self.DeepTransfer)), 0)
+        self.Percolation = pcr.cover(
+            pcr.max(0.0, pcr.min(self.MaxPercolation, self.DeepTransfer)), 0
         )
 
-        # self.ActLeakage = ifthenelse(self.Seepage > 0.0, -1.0 * self.Seepage, self.ActLeakage)
+        # self.ActLeakage = pcr.ifthenelse(self.Seepage > 0.0, -1.0 * self.Seepage, self.ActLeakage)
         self.SatWaterDepth = (
             self.SatWaterDepth
             + self.Transfer
@@ -2406,24 +2409,24 @@ class WflowModel(DynamicModel):
             - self.Percolation
         )
 
-        for n in arange(0, len(self.UStoreLayerThickness)):
-            self.UStoreLayerDepth[n] = ifthenelse(
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
+            self.UStoreLayerDepth[n] = pcr.ifthenelse(
                 self.ZiLayer == float(n),
                 self.UStoreLayerDepth[n] - self.Transfer,
                 self.UStoreLayerDepth[n],
             )
 
         # Determine % saturated taking into account subcell fraction
-        self.Sat = max(
+        self.Sat = pcr.max(
             self.SubCellFrac,
-            scalar(self.SatWaterDepth >= (self.SoilWaterCapacity * 0.999)),
+            pcr.scalar(self.SatWaterDepth >= (self.SoilWaterCapacity * 0.999)),
         )
 
         ##########################################################################
         # Horizontal (downstream) transport of water #############################
         ##########################################################################
 
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )  # Determine actual water depth
 
@@ -2433,12 +2436,12 @@ class WflowModel(DynamicModel):
 
         # self.logger.debug("Waterdem set to Altitude....")
         self.WaterDem = self.Altitude - (self.zi * 0.001)
-        self.waterSlope = max(
-            0.000001, slope(self.WaterDem) * celllength() / self.reallength
+        self.waterSlope = pcr.max(
+            0.000001, pcr.slope(self.WaterDem) * pcr.celllength() / self.reallength
         )
         if self.waterdem:
-            self.waterLdd = lddcreate(self.WaterDem, 1e35, 1e35, 1e35, 1e35)
-            # waterLdd = lddcreate(waterDem,1,1,1,1)
+            self.waterLdd = pcr.lddcreate(self.WaterDem, 1e35, 1e35, 1e35, 1e35)
+            # waterLdd = pcr.lddcreate(waterDem,1,1,1,1)
 
         # TODO: We should make a couple of itterations here...
 
@@ -2448,56 +2451,56 @@ class WflowModel(DynamicModel):
                     self.KsatHorFrac
                     * self.KsatVer
                     * self.waterSlope
-                    * exp(-self.SaturationDeficit / self.M)
+                    * pcr.exp(-self.SaturationDeficit / self.M)
                 )
             elif self.LateralMethod == 2:
                 # Lateral = Ksat * self.waterSlope
                 Lateral = (
                     self.KsatHorFrac
                     * self.KsatVer
-                    * (exp(-self.f * self.zi) - exp(-self.f * self.SoilThickness))
+                    * (pcr.exp(-self.f * self.zi) - pcr.exp(-self.f * self.SoilThickness))
                     * (1 / self.f)
                     / (self.SoilThickness - self.zi)
                     * self.waterSlope
                 )
 
-            MaxHor = max(0.0, min(Lateral, self.SatWaterDepth))
-            self.SatWaterFlux = accucapacityflux(
+            MaxHor = pcr.max(0.0, pcr.min(Lateral, self.SatWaterDepth))
+            self.SatWaterFlux = pcr.accucapacityflux(
                 self.waterLdd, self.SatWaterDepth, MaxHor
             )
-            self.SatWaterDepth = accucapacitystate(
+            self.SatWaterDepth = pcr.accucapacitystate(
                 self.waterLdd, self.SatWaterDepth, MaxHor
             )
         else:
             #
-            # MaxHor = max(0,min(self.KsatVer * self.Slope * exp(-SaturationDeficit/self.M),self.SatWaterDepth*(self.thetaS-self.thetaR))) * timestepsecs/basetimestep
-            # MaxHor = max(0.0, min(self.KsatVer * self.Slope * exp(-selield' object does not support item assignmentf.SaturationDeficit / self.M),
+            # MaxHor = pcr.max(0,pcr.min(self.KsatVer * self.Slope * pcr.exp(-SaturationDeficit/self.M),self.SatWaterDepth*(self.thetaS-self.thetaR))) * timestepsecs/basetimestep
+            # MaxHor = pcr.max(0.0, pcr.min(self.KsatVer * self.Slope * pcr.exp(-selield' object does not support item assignmentf.SaturationDeficit / self.M),
             #                      self.SatWaterDepth))
             if self.LateralMethod == 1:
                 Lateral = (
                     self.KsatHorFrac
                     * self.KsatVer
                     * self.waterSlope
-                    * exp(-self.SaturationDeficit / self.M)
+                    * pcr.exp(-self.SaturationDeficit / self.M)
                 )
             elif self.LateralMethod == 2:
                 # Lateral = Ksat * self.waterSlope
                 Lateral = (
                     self.KsatHorFrac
                     * self.KsatVer
-                    * (exp(-self.f * self.zi) - exp(-self.f * self.SoilThickness))
+                    * (pcr.exp(-self.f * self.zi) - pcr.exp(-self.f * self.SoilThickness))
                     * (1 / self.f)
                     / (self.SoilThickness - self.zi + 1.0)
                     * self.waterSlope
                 )
 
-            MaxHor = max(0.0, min(Lateral, self.SatWaterDepth))
+            MaxHor = pcr.max(0.0, pcr.min(Lateral, self.SatWaterDepth))
 
             # MaxHor = self.ZeroMap
-            self.SatWaterFlux = accucapacityflux(
+            self.SatWaterFlux = pcr.accucapacityflux(
                 self.TopoLdd, self.SatWaterDepth, MaxHor
             )
-            self.SatWaterDepth = accucapacitystate(
+            self.SatWaterDepth = pcr.accucapacitystate(
                 self.TopoLdd, self.SatWaterDepth, MaxHor
             )
 
@@ -2514,17 +2517,17 @@ class WflowModel(DynamicModel):
         self.SatWaterDepth = self.SatWaterDepth - self.ExfiltWater
 
         # Re-determine UStoreCapacity
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )  # Determine actual water depth
 
         self.SumThickness = self.ZeroMap
         self.ZiLayer = self.ZeroMap
-        for n in arange(0, len(self.UStoreLayerThickness)):
+        for n in np.arange(0, len(self.UStoreLayerThickness)):
             # Find layer with  zi level
-            self.ZiLayer = ifthenelse(
+            self.ZiLayer = pcr.ifthenelse(
                 self.zi > self.SumThickness,
-                min(self.ZeroMap + float(n), self.nrLayersMap - 1),
+                pcr.min(self.ZeroMap + float(n), self.nrLayersMap - 1),
                 self.ZiLayer,
             )
 
@@ -2537,7 +2540,7 @@ class WflowModel(DynamicModel):
         l_T = []
 
         # redistribute soil moisture (balance)
-        for n in arange(len(self.UStoreLayerThickness)):
+        for n in np.arange(len(self.UStoreLayerThickness)):
             self.SumLayer = self.SumThickness
             l_T.append(self.SumThickness)
             self.SumThickness = self.UStoreLayerThickness[n] + self.SumThickness
@@ -2545,9 +2548,9 @@ class WflowModel(DynamicModel):
             l_Thickness.append(self.SumThickness)
             # Height of unsat zone in layer n
             self.L.append(
-                ifthenelse(
+                pcr.ifthenelse(
                     self.ZiLayer == float(n),
-                    ifthenelse(
+                    pcr.ifthenelse(
                         self.ZeroMap + float(n) > 0,
                         self.zi - l_Thickness[n - 1],
                         self.zi,
@@ -2560,13 +2563,13 @@ class WflowModel(DynamicModel):
 
         self.ExfiltFromUstore = self.ZeroMap
 
-        for n in arange(len(self.UStoreLayerThickness) - 1, -1, -1):
-            diff = max(
+        for n in np.arange(len(self.UStoreLayerThickness) - 1, -1, -1):
+            diff = pcr.max(
                 self.ZeroMap,
-                cover(self.UStoreLayerDepth[n], 0.0)
-                - ifthenelse(self.zi <= l_T[n], 0.0, self.storage[n]),
+                pcr.cover(self.UStoreLayerDepth[n], 0.0)
+                - pcr.ifthenelse(self.zi <= l_T[n], 0.0, self.storage[n]),
             )
-            self.ExfiltFromUstore = ifthenelse(diff > 0, diff, self.ZeroMap)
+            self.ExfiltFromUstore = pcr.ifthenelse(diff > 0, diff, self.ZeroMap)
             self.UStoreLayerDepth[n] = self.UStoreLayerDepth[n] - diff
 
             if n > 0:
@@ -2593,7 +2596,7 @@ class WflowModel(DynamicModel):
 
         self.CumInfiltExcess = self.CumInfiltExcess + self.InfiltExcess
 
-        # self.ExfiltFromUstore = ifthenelse(self.zi == 0.0,self.ExfiltFromUstore,self.ZeroMap)
+        # self.ExfiltFromUstore = pcr.ifthenelse(self.zi == 0.0,self.ExfiltFromUstore,self.ZeroMap)
 
         self.ExfiltWater = self.ExfiltWater + self.ExfiltFromUstore
 
@@ -2601,20 +2604,20 @@ class WflowModel(DynamicModel):
 
         ponding_add = self.ZeroMap
         if self.nrpaddyirri > 0:
-            ponding_add = cover(
-                min(ifthen(self.h_p > 0, self.inund), self.h_p - self.PondingDepth), 0.0
+            ponding_add = pcr.cover(
+                pcr.min(pcr.ifthen(self.h_p > 0, self.inund), self.h_p - self.PondingDepth), 0.0
             )
             self.PondingDepth = self.PondingDepth + ponding_add
             irr_depth = (
-                ifthenelse(
+                pcr.ifthenelse(
                     self.PondingDepth < self.h_min, self.h_max - self.PondingDepth, 0.0
                 )
                 * self.CRPST
             )
-            sqmarea = areatotal(
+            sqmarea = pcr.areatotal(
                 self.reallength * self.reallength, self.IrrigationPaddyAreas
             )
-            self.IrriDemandm3 = cover((irr_depth / 1000.0) * sqmarea, 0)
+            self.IrriDemandm3 = pcr.cover((irr_depth / 1000.0) * sqmarea, 0)
             IRDemand = idtoid(
                 self.IrrigationPaddyAreas,
                 self.IrrigationSurfaceIntakes,
@@ -2622,7 +2625,7 @@ class WflowModel(DynamicModel):
             ) * (-1.0 / self.timestepsecs)
 
             self.IRDemand = IRDemand
-            self.Inflow = cover(IRDemand, self.Inflow)
+            self.Inflow = pcr.cover(IRDemand, self.Inflow)
             self.irr_depth = irr_depth
 
         UStoreCapacity = (
@@ -2632,7 +2635,7 @@ class WflowModel(DynamicModel):
         )
         self.UStoreDepth = sum_list_cover(self.UStoreLayerDepth, self.ZeroMap)
 
-        Ksat = self.KsatVer * exp(-self.f * self.zi)
+        Ksat = self.KsatVer * pcr.exp(-self.f * self.zi)
 
         SurfaceWater = self.WaterLevel / 1000.0  # SurfaceWater (mm)
         self.CumSurfaceWater = self.CumSurfaceWater + SurfaceWater
@@ -2642,13 +2645,13 @@ class WflowModel(DynamicModel):
         # - self.MaxReinFilt: a map with reinfilt locations (usually the river mak) can be supplied)
         # - take into account that the river may not cover the whole cell
         if self.reInfilt:
-            self.reinfiltwater = min(
+            self.reinfiltwater = pcr.min(
                 self.MaxReinfilt,
-                max(
+                pcr.max(
                     0,
-                    min(
+                    pcr.min(
                         SurfaceWater * self.RiverWidth / self.reallength * 0.7,
-                        min(self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity),
+                        pcr.min(self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity),
                     ),
                 ),
             )
@@ -2671,7 +2674,7 @@ class WflowModel(DynamicModel):
                 - ponding_add
             )
         else:
-            self.InwaterMM = max(
+            self.InwaterMM = pcr.max(
                 0.0,
                 self.ExfiltWater
                 + self.ExcessWater
@@ -2701,10 +2704,10 @@ class WflowModel(DynamicModel):
                 self.ReservoirSimpleAreas,
                 timestepsecs=self.timestepsecs,
             )
-            self.OutflowDwn = upstream(
-                self.TopoLddOrg, cover(self.OutflowSR, scalar(0.0))
+            self.OutflowDwn = pcr.upstream(
+                self.TopoLddOrg, pcr.cover(self.OutflowSR, pcr.scalar(0.0))
             )
-            self.Inflow = self.OutflowDwn + cover(self.Inflow, self.ZeroMap)
+            self.Inflow = self.OutflowDwn + pcr.cover(self.Inflow, self.ZeroMap)
         elif self.nrresComplex > 0:
             self.ReservoirWaterLevel, self.OutflowCR, self.ResPrecipCR, self.ResEvapCR, self.ReservoirVolumeCR = complexreservoir(
                 self.ReservoirWaterLevel,
@@ -2725,12 +2728,12 @@ class WflowModel(DynamicModel):
                 self.wf_supplyJulianDOY(),
                 timestepsecs=self.timestepsecs,
             )
-            self.OutflowDwn = upstream(
-                self.TopoLddOrg, cover(self.OutflowCR, scalar(0.0))
+            self.OutflowDwn = pcr.upstream(
+                self.TopoLddOrg, pcr.cover(self.OutflowCR, pcr.scalar(0.0))
             )
-            self.Inflow = self.OutflowDwn + cover(self.Inflow, self.ZeroMap)
+            self.Inflow = self.OutflowDwn + pcr.cover(self.Inflow, self.ZeroMap)
         else:
-            self.Inflow = cover(self.Inflow, self.ZeroMap)
+            self.Inflow = pcr.cover(self.Inflow, self.ZeroMap)
 
         self.ExfiltWaterCubic = self.ExfiltWater * self.ToCubic
         self.SubCellGWRunoffCubic = self.SubCellGWRunoff * self.ToCubic
@@ -2740,17 +2743,17 @@ class WflowModel(DynamicModel):
         # self.Inwater = self.Inwater + self.Inflow  # Add abstractions/inflows in m^3/sec
 
         # Check if we do not try to abstract more runoff then present
-        self.InflowKinWaveCell = upstream(
+        self.InflowKinWaveCell = pcr.upstream(
             self.TopoLdd, self.SurfaceRunoff
         )  # NG The extraction should be equal to the discharge upstream cell. You should not make the abstraction depended on the downstream cell, because they are correlated. During a stationary sum they will get equal to each other.
         MaxExtract = self.InflowKinWaveCell + self.Inwater  # NG
         # MaxExtract = self.SurfaceRunoff + self.Inwater
-        self.SurfaceWaterSupply = ifthenelse(
-            self.Inflow < 0.0, min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+        self.SurfaceWaterSupply = pcr.ifthenelse(
+            self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
         )
         self.OldSurfaceRunoff = self.SurfaceRunoff  # NG Store for iteration
         self.OldInwater = self.Inwater
-        self.Inwater = self.Inwater + ifthenelse(
+        self.Inwater = self.Inwater + pcr.ifthenelse(
             self.SurfaceWaterSupply > 0, -1.0 * self.SurfaceWaterSupply, self.Inflow
         )
 
@@ -2760,7 +2763,7 @@ class WflowModel(DynamicModel):
         # per distance along stream
         q = self.Inwater / self.DCL
         # discharge (m3/s)
-        self.SurfaceRunoff = kinematic(
+        self.SurfaceRunoff = pcr.kinematic(
             self.TopoLdd,
             self.SurfaceRunoff,
             q,
@@ -2775,21 +2778,21 @@ class WflowModel(DynamicModel):
         # at the flow in the upstream cell) and iterate if needed
         self.nrit = 0
         self.breakoff = 0.0001
-        if float(mapminimum(spatial(self.Inflow))) < 0.0:
+        if float(pcr.mapminimum(pcr.spatial(self.Inflow))) < 0.0:
             while True:
                 self.nrit += 1
                 oldsup = self.SurfaceWaterSupply
-                self.InflowKinWaveCell = upstream(self.TopoLdd, self.SurfaceRunoff)
+                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.SurfaceRunoff)
                 ##########################################################################
                 # Iterate to make a better estimation for the supply #####################
                 # (Runoff calculation via Kinematic wave) ################################
                 ##########################################################################
                 MaxExtract = self.InflowKinWaveCell + self.OldInwater
-                self.SurfaceWaterSupply = ifthenelse(
-                    self.Inflow < 0.0, min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+                self.SurfaceWaterSupply = pcr.ifthenelse(
+                    self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
                 )
                 # Fraction of demand that is not used but flows back into the river get fracttion and move to return locations
-                self.DemandReturnFlow = cover(
+                self.DemandReturnFlow = pcr.cover(
                     idtoid(
                         self.IrrigationSurfaceIntakes,
                         self.IrrigationSurfaceReturn,
@@ -2800,7 +2803,7 @@ class WflowModel(DynamicModel):
 
                 self.Inwater = (
                     self.OldInwater
-                    + ifthenelse(
+                    + pcr.ifthenelse(
                         self.SurfaceWaterSupply > 0,
                         -1.0 * self.SurfaceWaterSupply,
                         self.Inflow,
@@ -2810,7 +2813,7 @@ class WflowModel(DynamicModel):
                 # per distance along stream
                 q = self.Inwater / self.DCL
                 # discharge (m3/s)
-                self.SurfaceRunoff = kinematic(
+                self.SurfaceRunoff = pcr.kinematic(
                     self.TopoLdd,
                     self.OldSurfaceRunoff,
                     q,
@@ -2824,13 +2827,13 @@ class WflowModel(DynamicModel):
                     self.SurfaceRunoff * self.QMMConv
                 )  # SurfaceRunoffMM (mm) from SurfaceRunoff (m3/s)
 
-                self.InflowKinWaveCell = upstream(self.TopoLdd, self.OldSurfaceRunoff)
-                deltasup = float(mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
+                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.OldSurfaceRunoff)
+                deltasup = float(pcr.mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
 
                 if deltasup < self.breakoff or self.nrit >= self.maxitsupply:
                     break
 
-            self.InflowKinWaveCell = upstream(self.TopoLdd, self.SurfaceRunoff)
+            self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.SurfaceRunoff)
             self.updateRunOff()
         else:
             self.SurfaceRunoffMM = (
@@ -2847,11 +2850,11 @@ class WflowModel(DynamicModel):
                 self.IrrigationAreas,
                 self.SurfaceWaterSupply * (1 - self.DemandReturnFlowFraction),
             )
-            sqmarea = areatotal(
-                self.reallength * self.reallength, nominal(self.IrrigationAreas)
+            sqmarea = pcr.areatotal(
+                self.reallength * self.reallength, pcr.nominal(self.IrrigationAreas)
             )
 
-            self.IRSupplymm = cover(
+            self.IRSupplymm = pcr.cover(
                 IRSupplymm / (sqmarea / 1000.0 / self.timestepsecs), 0.0
             )
 
@@ -2859,15 +2862,15 @@ class WflowModel(DynamicModel):
             # loop over irrigation areas and spread-out the supply over the area
             IRSupplymm = idtoid(
                 self.IrrigationSurfaceIntakes,
-                ifthen(self.IrriDemandm3 > 0, self.IrrigationPaddyAreas),
+                pcr.ifthen(self.IrriDemandm3 > 0, self.IrrigationPaddyAreas),
                 self.SurfaceWaterSupply,
             )
-            sqmarea = areatotal(
+            sqmarea = pcr.areatotal(
                 self.reallength * self.reallength,
-                nominal(ifthen(self.IrriDemandm3 > 0, self.IrrigationPaddyAreas)),
+                pcr.nominal(pcr.ifthen(self.IrriDemandm3 > 0, self.IrrigationPaddyAreas)),
             )
 
-            self.IRSupplymm = cover(
+            self.IRSupplymm = pcr.cover(
                 ((IRSupplymm * self.timestepsecs * 1000) / sqmarea), 0.0
             )
 
@@ -2886,26 +2889,26 @@ class WflowModel(DynamicModel):
         # first column (nr 1). Assumes that outputloc and columns match!
 
         if self.updating:
-            self.QM = timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            self.QM = pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
 
             # Now update the state. Just add to the Ustore
             # self.UStoreDepth =  result
             # No determine multiplication ratio for each gauge influence area.
             # For missing gauges 1.0 is assumed (no change).
-            # UpDiff = areamaximum(QM,  self.UpdateMap) - areamaximum(self.SurfaceRunoffMM, self.UpdateMap)
-            UpRatio = areamaximum(self.QM, self.UpdateMap) / areamaximum(
+            # UpDiff = pcr.areamaximum(QM,  self.UpdateMap) - pcr.areamaximum(self.SurfaceRunoffMM, self.UpdateMap)
+            UpRatio = pcr.areamaximum(self.QM, self.UpdateMap) / pcr.areamaximum(
                 self.SurfaceRunoffMM, self.UpdateMap
             )
 
-            UpRatio = cover(areaaverage(UpRatio, self.TopoId), 1.0)
+            UpRatio = pcr.cover(pcr.areaaverage(UpRatio, self.TopoId), 1.0)
             # Now split between Soil and Kyn  wave
-            self.UpRatioKyn = min(
+            self.UpRatioKyn = pcr.min(
                 self.MaxUpdMult,
-                max(self.MinUpdMult, (UpRatio - 1.0) * self.UpFrac + 1.0),
+                pcr.max(self.MinUpdMult, (UpRatio - 1.0) * self.UpFrac + 1.0),
             )
-            UpRatioSoil = min(
+            UpRatioSoil = pcr.min(
                 self.MaxUpdMult,
-                max(self.MinUpdMult, (UpRatio - 1.0) * (1.0 - self.UpFrac) + 1.0),
+                pcr.max(self.MinUpdMult, (UpRatio - 1.0) * (1.0 - self.UpFrac) + 1.0),
             )
 
             # update/nudge self.UStoreDepth for the whole upstream area,
@@ -2933,7 +2936,7 @@ class WflowModel(DynamicModel):
         # self.RootStore_unsat: root water storage [mm] in unsaturated store (excluding thetaR)
         # self.RootStore: total root water storage [mm] (excluding thetaR)
 
-        self.RootStore_sat = max(0.0, self.ActRootingDepth - self.zi) * (
+        self.RootStore_sat = pcr.max(0.0, self.ActRootingDepth - self.zi) * (
             self.thetaS - self.thetaR
         )
 
@@ -2942,21 +2945,21 @@ class WflowModel(DynamicModel):
         self.vwc = []
         self.vwc_perc = []
 
-        for n in arange(len(self.UStoreLayerThickness)):
+        for n in np.arange(len(self.UStoreLayerThickness)):
 
-            fracRoot = ifthenelse(
+            fracRoot = pcr.ifthenelse(
                 self.ZiLayer > float(n),
-                min(
+                pcr.min(
                     1.0,
-                    max(
+                    pcr.max(
                         0.0,
-                        (min(self.ActRootingDepth, self.zi) - self.SumThickness)
+                        (pcr.min(self.ActRootingDepth, self.zi) - self.SumThickness)
                         / self.UStoreLayerThickness[n],
                     ),
                 ),
-                min(
+                pcr.min(
                     1.0,
-                    max(
+                    pcr.max(
                         0.0,
                         (self.ActRootingDepth - self.SumThickness)
                         / (self.zi + 1 - self.SumThickness),
@@ -2967,7 +2970,7 @@ class WflowModel(DynamicModel):
             self.SumThickness = self.UStoreLayerThickness[n] + self.SumThickness
 
             self.vwc.append(
-                ifthenelse(
+                pcr.ifthenelse(
                     self.ZiLayer > float(n),
                     self.UStoreLayerDepth[n] / self.UStoreLayerThickness[n]
                     + self.thetaR,
@@ -2976,7 +2979,7 @@ class WflowModel(DynamicModel):
                             (
                                 self.UStoreLayerDepth[n]
                                 + (self.thetaS - self.thetaR)
-                                * min(
+                                * pcr.min(
                                     self.UStoreLayerThickness[n],
                                     (self.SumThickness - self.zi),
                                 )
@@ -2990,7 +2993,7 @@ class WflowModel(DynamicModel):
 
             self.vwc_perc.append((self.vwc[n] / self.thetaS) * 100.0)
 
-            self.RootStore_unsat = self.RootStore_unsat + cover(
+            self.RootStore_unsat = self.RootStore_unsat + pcr.cover(
                 fracRoot * self.UStoreLayerDepth[n], 0.0
             )
 
@@ -3006,11 +3009,11 @@ class WflowModel(DynamicModel):
         self.QCatchmentMM = self.SurfaceRunoff * self.QMMConvUp
         self.RunoffCoeff = (
             self.QCatchmentMM
-            / catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
-            / catchmenttotal(cover(1.0), self.TopoLdd)
+            / pcr.catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
+            / pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
         )
-        # self.AA = catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
-        # self.BB = catchmenttotal(cover(1.0), self.TopoLdd)
+        # self.AA = pcr.catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
+        # self.BB = pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
         # Single cell based water budget. snow not included yet.
 
         self.CellStorage = (
@@ -3022,9 +3025,9 @@ class WflowModel(DynamicModel):
         self.DeltaStorage = self.CellStorage - self.OrgStorage
         OutFlow = self.SatWaterFlux
         if self.waterdem:
-            CellInFlow = upstream(self.waterLdd, scalar(self.SatWaterFlux))
+            CellInFlow = pcr.upstream(self.waterLdd, pcr.scalar(self.SatWaterFlux))
         else:
-            CellInFlow = upstream(self.TopoLdd, scalar(self.SatWaterFlux))
+            CellInFlow = pcr.upstream(self.TopoLdd, pcr.scalar(self.SatWaterFlux))
 
         self.CumOutFlow = self.CumOutFlow + OutFlow
         self.CumActInfilt = self.CumActInfilt + self.ActInfilt
@@ -3036,7 +3039,7 @@ class WflowModel(DynamicModel):
 
         self.CumInt = self.CumInt + self.Interception
 
-        self.SnowCover = ifthenelse(self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap)
+        self.SnowCover = pcr.ifthenelse(self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap)
         self.CumLeakage = self.CumLeakage + self.ActLeakage
         self.CumInwaterMM = self.CumInwaterMM + self.InwaterMM
         self.CumExfiltWater = self.CumExfiltWater + self.ExfiltWater

--- a/wflow/wflow_sbm.py
+++ b/wflow/wflow_sbm.py
@@ -84,18 +84,11 @@ usage
 
 """
 
-import numpy
-
-# import pcrut
-import sys
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-from wflow.wflow_funcs import *
 from wflow.wflow_adapt import *
-
+from wflow.wflow_funcs import *
 
 wflow = "wflow_sbm: "
 

--- a/wflow/wflow_sbm_old.py
+++ b/wflow/wflow_sbm_old.py
@@ -86,18 +86,11 @@ usage
 
 # TODO: add Et reduction in unsat zone based on deficit
 
-import numpy
-
-# import pcrut
-import os
 import os.path
-import getopt
-
 
 from wflow.wf_DynamicFramework import *
-from wflow.wflow_funcs import *
 from wflow.wflow_adapt import *
-
+from wflow.wflow_funcs import *
 
 wflow = "wflow_sbm: "
 

--- a/wflow/wflow_sbm_old.py
+++ b/wflow/wflow_sbm_old.py
@@ -88,6 +88,7 @@ usage
 
 import os.path
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 from wflow.wflow_funcs import *
@@ -131,31 +132,31 @@ def actEvap_SBM(
 
     # Step 1 from saturated zone, use rootingDepth as a limiting factor
     # rootsinWater = WTable < RootingDepth
-    # ActEvapSat = ifthenelse(rootsinWater,min(PotTrans,SatWaterDepth),0.0)
+    # ActEvapSat = pcr.ifthenelse(rootsinWater,pcr.min(PotTrans,SatWaterDepth),0.0)
     # new method:
     # use sCurve to determine if the roots are wet.At the moment this ise set
     # to be a 0-1 curve
     wetroots = sCurve(WTable, a=RootingDepth, c=smoothpar)
-    # wetroots = ifthenelse(WTable <= RootingDepth, scalar(1.0), scalar(0.0))
-    ActEvapSat = min(PotTrans * wetroots, SatWaterDepth)
+    # wetroots = pcr.ifthenelse(WTable <= RootingDepth, pcr.scalar(1.0), pcr.scalar(0.0))
+    ActEvapSat = pcr.min(PotTrans * wetroots, SatWaterDepth)
 
     SatWaterDepth = SatWaterDepth - ActEvapSat
     RestPotEvap = PotTrans - ActEvapSat
 
     # now try unsat store
-    # AvailCap = min(1.0, max(0.0, (WTable - RootingDepth) / (RootingDepth + 1.0)))
+    # AvailCap = pcr.min(1.0, pcr.max(0.0, (WTable - RootingDepth) / (RootingDepth + 1.0)))
 
     if ust >= 1:
         AvailCap = UStoreDepth * 0.99
     else:
-        AvailCap = max(
+        AvailCap = pcr.max(
             0.0,
-            ifthenelse(
-                WTable < RootingDepth, cover(1.0), RootingDepth / (WTable + 1.0)
+            pcr.ifthenelse(
+                WTable < RootingDepth, pcr.cover(1.0), RootingDepth / (WTable + 1.0)
             ),
         )
     MaxExtr = AvailCap * UStoreDepth
-    ActEvapUStore = min(MaxExtr, RestPotEvap, UStoreDepth)
+    ActEvapUStore = pcr.min(MaxExtr, RestPotEvap, UStoreDepth)
     UStoreDepth = UStoreDepth - ActEvapUStore
 
     ActEvap = ActEvapSat + ActEvapUStore
@@ -184,13 +185,13 @@ def SnowPackHBV(Snow, SnowWater, Precipitation, Temperature, TTI, TT, TTM, Cfmax
     CFR = 0.05000  # refreeing efficiency constant in refreezing of freewater in snow
     SFCF = 1.0  # correction factor for snowfall
 
-    RainFrac = ifthenelse(
+    RainFrac = pcr.ifthenelse(
         1.0 * TTI == 0.0,
-        ifthenelse(Temperature <= TT, scalar(0.0), scalar(1.0)),
-        min((Temperature - (TT - TTI / 2)) / TTI, scalar(1.0)),
+        pcr.ifthenelse(Temperature <= TT, pcr.scalar(0.0), pcr.scalar(1.0)),
+        pcr.min((Temperature - (TT - TTI / 2)) / TTI, pcr.scalar(1.0)),
     )
-    RainFrac = max(
-        RainFrac, scalar(0.0)
+    RainFrac = pcr.max(
+        RainFrac, pcr.scalar(0.0)
     )  # fraction of precipitation which falls as rain
     SnowFrac = 1 - RainFrac  # fraction of precipitation which falls as snow
     Precipitation = (
@@ -199,24 +200,24 @@ def SnowPackHBV(Snow, SnowWater, Precipitation, Temperature, TTI, TT, TTM, Cfmax
 
     SnowFall = SnowFrac * Precipitation  # snowfall depth
     RainFall = RainFrac * Precipitation  # rainfall depth
-    PotSnowMelt = ifthenelse(
-        Temperature > TTM, Cfmax * (Temperature - TTM), scalar(0.0)
+    PotSnowMelt = pcr.ifthenelse(
+        Temperature > TTM, Cfmax * (Temperature - TTM), pcr.scalar(0.0)
     )  # Potential snow melt, based on temperature
-    PotRefreezing = ifthenelse(
+    PotRefreezing = pcr.ifthenelse(
         Temperature < TTM, Cfmax * CFR * (TTM - Temperature), 0.0
     )  # Potential refreezing, based on temperature
-    Refreezing = ifthenelse(
-        Temperature < TTM, min(PotRefreezing, SnowWater), 0.0
+    Refreezing = pcr.ifthenelse(
+        Temperature < TTM, pcr.min(PotRefreezing, SnowWater), 0.0
     )  # actual refreezing
     # No landuse correction here
-    SnowMelt = min(PotSnowMelt, Snow)  # actual snow melt
+    SnowMelt = pcr.min(PotSnowMelt, Snow)  # actual snow melt
     Snow = Snow + SnowFall + Refreezing - SnowMelt  # dry snow content
     SnowWater = SnowWater - Refreezing  # free water content in snow
     MaxSnowWater = Snow * WHC  # Max water in the snow
     SnowWater = (
         SnowWater + SnowMelt + RainFall
     )  # Add all water and potentially supersaturate the snowpack
-    RainFall = max(SnowWater - MaxSnowWater, 0.0)  # rain + surpluss snowwater
+    RainFall = pcr.max(SnowWater - MaxSnowWater, 0.0)  # rain + surpluss snowwater
     SnowWater = SnowWater - RainFall
 
     return Snow, SnowWater, SnowMelt, RainFall, SnowFall
@@ -235,19 +236,19 @@ def GlacierMelt(GlacierStore, Snow, Temperature, TT, Cfmax):
     :returns: GlacierStore,GlacierMelt,
     """
 
-    PotMelt = ifthenelse(
-        Temperature > TT, Cfmax * (Temperature - TT), scalar(0.0)
+    PotMelt = pcr.ifthenelse(
+        Temperature > TT, Cfmax * (Temperature - TT), pcr.scalar(0.0)
     )  # Potential snow melt, based on temperature
 
-    GlacierMelt = ifthenelse(
-        Snow > 10.0, min(PotMelt, GlacierStore), cover(0.0)
+    GlacierMelt = pcr.ifthenelse(
+        Snow > 10.0, pcr.min(PotMelt, GlacierStore), pcr.cover(0.0)
     )  # actual Glacier melt
     GlacierStore = GlacierStore - GlacierMelt  # dry snow content
 
     return GlacierStore, GlacierMelt
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
     .. versionchanged:: 0.91
         - Calculation of GWScale moved to resume() to allow fitting.
@@ -260,11 +261,11 @@ class WflowModel(DynamicModel):
   """
 
     def __init__(self, cloneMap, Dir, RunDir, configfile):
-        DynamicModel.__init__(self)
+        pcraster.framework.DynamicModel.__init__(self)
 
         self.caseName = os.path.abspath(Dir)
         self.clonemappath = os.path.join(os.path.abspath(Dir), "staticmaps", cloneMap)
-        setclone(self.clonemappath)
+        pcr.setclone(self.clonemappath)
         self.runId = RunDir
         self.Dir = os.path.abspath(Dir)
         self.configfile = configfile
@@ -282,9 +283,9 @@ class WflowModel(DynamicModel):
         :return: demand
         """
 
-        Et_diff = areaaverage(pottrans - acttrans, nominal(irareas))
+        Et_diff = pcr.areaaverage(pottrans - acttrans, pcr.nominal(irareas))
         # Now determine demand in m^3/s for each area
-        sqmarea = areatotal(self.reallength * self.reallength, nominal(irareas))
+        sqmarea = pcr.areatotal(self.reallength * self.reallength, pcr.nominal(irareas))
         m3sec = Et_diff * sqmarea / 1000.0 / self.timestepsecs
 
         return Et_diff, m3sec
@@ -507,10 +508,10 @@ class WflowModel(DynamicModel):
         global multpars
         global updateCols
 
-        self.thestep = scalar(0)
+        self.thestep = pcr.scalar(0)
         self.basetimestep = 86400
         self.SSSF = False
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
         self.logger.info("running for " + str(self.nrTimeSteps()) + " timesteps")
 
@@ -593,28 +594,28 @@ class WflowModel(DynamicModel):
         )
 
         # 2: Input base maps ########################################################
-        subcatch = ordinal(
+        subcatch = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # Determines the area of calculations (all cells > 0)
-        subcatch = ifthen(subcatch > 0, subcatch)
+        subcatch = pcr.ifthen(subcatch > 0, subcatch)
 
         self.Altitude = self.wf_readmap(
             os.path.join(self.Dir, wflow_dem), 0.0, fail=True
-        )  # * scalar(defined(subcatch)) # DEM
-        self.TopoLdd = ldd(
+        )  # * pcr.scalar(pcr.defined(subcatch)) # DEM
+        self.TopoLdd = pcr.ldd(
             self.wf_readmap(os.path.join(self.Dir, wflow_ldd), 0.0, fail=True)
         )  # Local
-        self.TopoId = ordinal(
+        self.TopoId = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # area map
-        self.River = cover(
-            boolean(
+        self.River = pcr.cover(
+            pcr.boolean(
                 self.wf_readmap(os.path.join(self.Dir, wflow_river), 0.0, fail=True)
             ),
             0,
         )
 
-        self.RiverLength = cover(
+        self.RiverLength = pcr.cover(
             self.wf_readmap(os.path.join(self.Dir, wflow_riverlength), 0.0), 0.0
         )
         # Factor to multiply riverlength with (defaults to 1.0)
@@ -624,18 +625,18 @@ class WflowModel(DynamicModel):
 
         # read landuse and soilmap and make sure there are no missing points related to the
         # subcatchment map. Currently sets the lu and soil type  type to 1
-        self.LandUse = ordinal(
+        self.LandUse = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_landuse), 0.0, fail=True)
         )
-        self.LandUse = cover(self.LandUse, ordinal(subcatch > 0))
-        self.Soil = ordinal(
+        self.LandUse = pcr.cover(self.LandUse, pcr.ordinal(subcatch > 0))
+        self.Soil = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_soil), 0.0, fail=True)
         )
-        self.Soil = cover(self.Soil, ordinal(subcatch > 0))
-        self.OutputLoc = ordinal(
+        self.Soil = pcr.cover(self.Soil, pcr.ordinal(subcatch > 0))
+        self.OutputLoc = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_gauges), 0.0, fail=True)
         )  # location of output gauge(s)
-        self.InflowLoc = ordinal(
+        self.InflowLoc = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_inflow), 0.0)
         )  # location abstractions/inflows.
         self.RiverWidth = self.wf_readmap(os.path.join(self.Dir, wflow_riverwidth), 0.0)
@@ -646,7 +647,7 @@ class WflowModel(DynamicModel):
         self.SubCatchFlowOnly = int(
             configget(self.config, "model", "SubCatchFlowOnly", "0")
         )
-        self.OutputId = ordinal(
+        self.OutputId = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_subcatch), 0.0, fail=True)
         )  # location of subcatchment
         # Temperature correction poer cell to add
@@ -662,14 +663,14 @@ class WflowModel(DynamicModel):
             0.0,
         )
 
-        self.ZeroMap = 0.0 * scalar(subcatch)  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(subcatch)  # map with only zero's
 
         # Set static initial values here #########################################
         self.pi = 3.1416
         self.e = 2.7183
         self.SScale = 100.0
-        self.Latitude = ycoordinate(boolean(self.Altitude))
-        self.Longitude = xcoordinate(boolean(self.Altitude))
+        self.Latitude = pcr.ycoordinate(pcr.boolean(self.Altitude))
+        self.Longitude = pcr.xcoordinate(pcr.boolean(self.Altitude))
 
         # Read parameters NEW Method
         self.logger.info("Linking parameters to landuse, catchment and soil...")
@@ -711,7 +712,7 @@ class WflowModel(DynamicModel):
                 )
 
             self.Cmax = self.Sl * self.LAI + self.Swood
-            self.CanopyGapFraction = exp(-self.Kext * self.LAI)
+            self.CanopyGapFraction = pcr.exp(-self.Kext * self.LAI)
             # TODO: Add MAXLAI and CWf lookup
         else:
             self.Cmax = self.readtblDefault(
@@ -882,25 +883,25 @@ class WflowModel(DynamicModel):
 
         if hasattr(self, "ReserVoirLocs"):
             # Check if we have reservoirs
-            tt = pcr2numpy(self.ReserVoirLocs, 0.0)
+            tt = pcr.pcr2numpy(self.ReserVoirLocs, 0.0)
             self.nrres = tt.max()
             if self.nrres > 0:
                 self.logger.info("A total of " + str(self.nrres) + " reservoirs found.")
-                self.ReserVoirDownstreamLocs = downstream(
+                self.ReserVoirDownstreamLocs = pcr.downstream(
                     self.TopoLdd, self.ReserVoirLocs
                 )
                 self.TopoLddOrg = self.TopoLdd
-                self.TopoLdd = lddrepair(
-                    cover(ifthen(boolean(self.ReserVoirLocs), ldd(5)), self.TopoLdd)
+                self.TopoLdd = pcr.lddrepair(
+                    pcr.cover(pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)), self.TopoLdd)
                 )
         else:
             self.nrres = 0
 
         # Check if we have irrigation areas
-        tt = pcr2numpy(self.IrrigationAreas, 0.0)
+        tt = pcr.pcr2numpy(self.IrrigationAreas, 0.0)
         self.nrirri = tt.max()
 
-        self.Beta = scalar(0.6)  # For sheetflow
+        self.Beta = pcr.scalar(0.6)  # For sheetflow
 
         self.M = self.readtblDefault(
             self.Dir + "/" + self.intbl + "/M.tbl",
@@ -991,7 +992,7 @@ class WflowModel(DynamicModel):
                 / self.basetimestep
             )
 
-            self.cf_soil = min(
+            self.cf_soil = pcr.min(
                 0.99,
                 self.readtblDefault(
                     self.Dir + "/" + self.intbl + "/cf_soil.tbl",
@@ -1008,14 +1009,14 @@ class WflowModel(DynamicModel):
         self.xl, self.yl, self.reallength = pcrut.detRealCellLength(
             self.ZeroMap, sizeinmetres
         )
-        self.Slope = slope(self.Altitude)
-        # self.Slope=ifthen(boolean(self.TopoId),max(0.001,self.Slope*celllength()/self.reallength))
-        self.Slope = max(0.00001, self.Slope * celllength() / self.reallength)
-        Terrain_angle = scalar(atan(self.Slope))
+        self.Slope = pcr.slope(self.Altitude)
+        # self.Slope=pcr.ifthen(pcr.boolean(self.TopoId),pcr.max(0.001,self.Slope*celllength()/self.reallength))
+        self.Slope = pcr.max(0.00001, self.Slope * pcr.celllength() / self.reallength)
+        Terrain_angle = pcr.scalar(pcr.atan(self.Slope))
 
         self.wf_multparameters()
 
-        self.N = ifthenelse(self.River, self.NRiver, self.N)
+        self.N = pcr.ifthenelse(self.River, self.NRiver, self.N)
 
         # Determine river width from DEM, upstream area and yearly average discharge
         # Scale yearly average Q at outlet with upstream are to get Q over whole catchment
@@ -1023,50 +1024,50 @@ class WflowModel(DynamicModel):
         # "Noah J. Finnegan et al 2005 Controls on the channel width of rivers:
         # Implications for modeling fluvial incision of bedrock"
 
-        upstr = catchmenttotal(1, self.TopoLdd)
-        Qscale = upstr / mapmaximum(upstr) * Qmax
+        upstr = pcr.catchmenttotal(1, self.TopoLdd)
+        Qscale = upstr / pcr.mapmaximum(upstr) * Qmax
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (max(0.0001, windowaverage(self.Slope, celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
-        self.RiverWidth = ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
+        self.RiverWidth = pcr.ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
 
         # Only allow reinfiltration in river cells by default
 
         if not hasattr(self, "MaxReinfilt"):
-            self.MaxReinfilt = ifthenelse(
+            self.MaxReinfilt = pcr.ifthenelse(
                 self.River, self.ZeroMap + 999.0, self.ZeroMap
             )
 
         # soil thickness based on topographical index (see Environmental modelling: finding simplicity in complexity)
         # 1: calculate wetness index
         # 2: Scale the capacity (now actually a max capacity) based on the index, also apply a minmum capacity
-        WI = ln(
-            accuflux(self.TopoLdd, 1) / self.Slope
+        WI = pcr.ln(
+            pcr.accuflux(self.TopoLdd, 1) / self.Slope
         )  # Topographical wetnesss. Scale WI by zone/subcatchment assuming these ara also geological units
-        WIMax = areamaximum(WI, self.TopoId) * WIMaxScale
-        self.SoilThickness = max(
-            min(self.SoilThickness, (WI / WIMax) * self.SoilThickness),
+        WIMax = pcr.areamaximum(WI, self.TopoId) * WIMaxScale
+        self.SoilThickness = pcr.max(
+            pcr.min(self.SoilThickness, (WI / WIMax) * self.SoilThickness),
             self.SoilMinThickness,
         )
 
         self.SoilWaterCapacity = self.SoilThickness * (self.thetaS - self.thetaR)
 
         # limit roots to top 99% of first zone
-        self.RootingDepth = min(self.SoilThickness * 0.99, self.RootingDepth)
+        self.RootingDepth = pcr.min(self.SoilThickness * 0.99, self.RootingDepth)
 
         # subgrid runoff generation, determine CC (sharpness of S-Curve) for upper
         # en lower part and take average
-        self.DemMax = readmap(self.Dir + "/staticmaps/wflow_demmax")
-        self.DrainageBase = readmap(self.Dir + "/staticmaps/wflow_demmin")
-        self.CClow = min(
-            100.0, -ln(1.0 / 0.1 - 1) / min(-0.1, self.DrainageBase - self.Altitude)
+        self.DemMax = pcr.readmap(self.Dir + "/staticmaps/wflow_demmax")
+        self.DrainageBase = pcr.readmap(self.Dir + "/staticmaps/wflow_demmin")
+        self.CClow = pcr.min(
+            100.0, -ln(1.0 / 0.1 - 1) / pcr.min(-0.1, self.DrainageBase - self.Altitude)
         )
-        self.CCup = min(
-            100.0, -ln(1.0 / 0.1 - 1) / min(-0.1, self.Altitude - self.DemMax)
+        self.CCup = pcr.min(
+            100.0, -ln(1.0 / 0.1 - 1) / pcr.min(-0.1, self.Altitude - self.DemMax)
         )
         self.CC = (self.CClow + self.CCup) * 0.5
 
@@ -1074,7 +1075,7 @@ class WflowModel(DynamicModel):
         self.UpdateMap = self.ZeroMap
 
         if self.updating:
-            _tmp = pcr2numpy(self.OutputLoc, 0.0)
+            _tmp = pcr.pcr2numpy(self.OutputLoc, 0.0)
             gaugear = _tmp
             touse = numpy.zeros(gaugear.shape, dtype="int")
 
@@ -1082,14 +1083,14 @@ class WflowModel(DynamicModel):
                 idx = (gaugear == thecol).nonzero()
                 touse[idx] = thecol
 
-            self.UpdateMap = numpy2pcr(Nominal, touse, 0.0)
+            self.UpdateMap = pcr.numpy2pcr(pcr.Nominal, touse, 0.0)
             # Calculate distance to updating points (upstream) annd use to scale the correction
             # ldddist returns zero for cell at the gauges so add 1.0 tp result
-            self.DistToUpdPt = cover(
-                min(
-                    ldddist(self.TopoLdd, boolean(cover(self.UpdateMap, 0)), 1)
+            self.DistToUpdPt = pcr.cover(
+                pcr.min(
+                    ldddist(self.TopoLdd, pcr.boolean(pcr.cover(self.UpdateMap, 0)), 1)
                     * self.reallength
-                    / celllength(),
+                    / pcr.celllength(),
                     self.UpdMaxDist,
                 ),
                 self.UpdMaxDist,
@@ -1097,16 +1098,16 @@ class WflowModel(DynamicModel):
 
         # Initializing of variables
         self.logger.info("Initializing of model variables..")
-        self.TopoLdd = lddmask(self.TopoLdd, boolean(self.TopoId))
-        catchmentcells = maptotal(scalar(self.TopoId))
+        self.TopoLdd = pcr.lddmask(self.TopoLdd, pcr.boolean(self.TopoId))
+        catchmentcells = pcr.maptotal(pcr.scalar(self.TopoId))
 
         # Limit lateral flow per subcatchment (make pits at all subcatch boundaries)
         # This is very handy for Ribasim etc...
         if self.SubCatchFlowOnly > 0:
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
-            ds = downstream(self.TopoLdd, self.TopoId)
-            usid = ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = lddrepair(ifthenelse(boolean(usid), ldd(5), self.TopoLdd))
+            ds = pcr.downstream(self.TopoLdd, self.TopoId)
+            usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
+            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
 
         # Used to seperate output per LandUse/management classes
         OutZones = self.LandUse
@@ -1114,15 +1115,15 @@ class WflowModel(DynamicModel):
         self.QMMConv = self.timestepsecs / (
             self.reallength * self.reallength * 0.001
         )  # m3/s --> actial mm of water over the cell
-        # self.QMMConvUp = 1000.0 * self.timestepsecs / ( catchmenttotal(cover(1.0), self.TopoLdd) * self.reallength * self.reallength)  #m3/s --> mm over upstreams
+        # self.QMMConvUp = 1000.0 * self.timestepsecs / ( pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd) * self.reallength * self.reallength)  #m3/s --> mm over upstreams
         temp = (
-            catchmenttotal(cover(1.0), self.TopoLdd)
+            pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
             * self.reallength
             * 0.001
             * 0.001
             * self.reallength
         )
-        self.QMMConvUp = cover(self.timestepsecs * 0.001) / temp
+        self.QMMConvUp = pcr.cover(self.timestepsecs * 0.001) / temp
         self.ToCubic = (
             self.reallength * self.reallength * 0.001
         ) / self.timestepsecs  # m3/s
@@ -1160,19 +1161,19 @@ class WflowModel(DynamicModel):
         self.CumIF = self.ZeroMap
         self.CumActInfilt = self.ZeroMap
         self.IRSupplymm = self.ZeroMap
-        self.Aspect = scalar(aspect(self.Altitude))  # aspect [deg]
-        self.Aspect = ifthenelse(self.Aspect <= 0.0, scalar(0.001), self.Aspect)
+        self.Aspect = pcr.scalar(pcr.aspect(self.Altitude))  # aspect [deg]
+        self.Aspect = pcr.ifthenelse(self.Aspect <= 0.0, pcr.scalar(0.001), self.Aspect)
         # On Flat areas the Aspect function fails, fill in with average...
-        self.Aspect = ifthenelse(
-            defined(self.Aspect), self.Aspect, areaaverage(self.Aspect, self.TopoId)
+        self.Aspect = pcr.ifthenelse(
+            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
         )
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
         drainlength = detdrainlength(self.TopoLdd, self.xl, self.yl)
 
         # Multiply with Factor (taken from upscaling operation, defaults to 1.0 if no map is supplied
-        self.DCL = drainlength * max(1.0, self.RiverLengthFac)
+        self.DCL = drainlength * pcr.max(1.0, self.RiverLengthFac)
 
-        self.DCL = max(self.DCL, self.RiverLength)  # m
+        self.DCL = pcr.max(self.DCL, self.RiverLength)  # m
 
         # water depth (m)
         # set width for kinematic wave to cell width for all cells
@@ -1180,34 +1181,34 @@ class WflowModel(DynamicModel):
         # However, in the main river we have real flow so set the width to the
         # width of the river
 
-        self.Bw = ifthenelse(self.River, self.RiverWidth, self.Bw)
+        self.Bw = pcr.ifthenelse(self.River, self.RiverWidth, self.Bw)
 
         # Add rivers to the WaterFrac, but check with waterfrac map and correct
-        self.RiverFrac = min(
+        self.RiverFrac = pcr.min(
             1.0,
-            ifthenelse(
+            pcr.ifthenelse(
                 self.River, (self.RiverWidth * self.DCL) / (self.xl * self.yl), 0
             ),
         )
-        self.WaterFrac = min(1.0, self.WaterFrac + self.RiverFrac)
+        self.WaterFrac = pcr.min(1.0, self.WaterFrac + self.RiverFrac)
 
         # term for Alpha
         # Correct slope for extra length of the river in a gridcel
         riverslopecor = drainlength / self.DCL
-        # report(riverslopecor,"cor.map")
-        # report(self.Slope * riverslopecor,"slope.map")
-        self.AlpTerm = pow((self.N / (sqrt(self.Slope * riverslopecor))), self.Beta)
+        # pcr.report(riverslopecor,"cor.map")
+        # pcr.report(self.Slope * riverslopecor,"slope.map")
+        self.AlpTerm = pow((self.N / (pcr.sqrt(self.Slope * riverslopecor))), self.Beta)
         # power for Alpha
         self.AlpPow = (2.0 / 3.0) * self.Beta
         # initial approximation for Alpha
         # calculate catchmentsize
-        self.upsize = catchmenttotal(self.xl * self.yl, self.TopoLdd)
-        self.csize = areamaximum(self.upsize, self.TopoId)
+        self.upsize = pcr.catchmenttotal(self.xl * self.yl, self.TopoLdd)
+        self.csize = pcr.areamaximum(self.upsize, self.TopoId)
         # Save some summary maps
         self.logger.info("Saving summary maps...")
 
         if self.updating:
-            report(
+            pcr.report(
                 self.DistToUpdPt,
                 self.Dir + "/" + self.runId + "/outsum/DistToUpdPt.map",
             )
@@ -1292,7 +1293,7 @@ class WflowModel(DynamicModel):
         self.CellStorage = self.SatWaterDepth + self.UStoreDepth
 
         # Determine actual water depth
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )
         # TOPOG_SBM type soil stuff
@@ -1366,24 +1367,24 @@ class WflowModel(DynamicModel):
         # Read forcing data and dynamic parameters
 
         self.wf_updateparameters()
-        self.Precipitation = max(0.0, self.Precipitation)
+        self.Precipitation = pcr.max(0.0, self.Precipitation)
 
         # NB This may interfere with lintul link
         if hasattr(self, "LAI"):
             # Sl must also be defined
             ##TODO: add MAXLAI and CWf
             self.Cmax = self.Sl * self.LAI + self.Swood
-            self.CanopyGapFraction = exp(-self.Kext * self.LAI)
-            self.Ewet = (1 - exp(-self.Kext * self.LAI)) * self.PotenEvap
-            self.EoverR = ifthenelse(
+            self.CanopyGapFraction = pcr.exp(-self.Kext * self.LAI)
+            self.Ewet = (1 - pcr.exp(-self.Kext * self.LAI)) * self.PotenEvap
+            self.EoverR = pcr.ifthenelse(
                 self.Precipitation > 0.0,
-                min(0.25, cover(self.Ewet / max(0.0001, self.Precipitation), 0.0)),
+                pcr.min(0.25, pcr.cover(self.Ewet / pcr.max(0.0001, self.Precipitation), 0.0)),
                 0.0,
             )
             if hasattr(self, "MAXLAI") and hasattr(self, "CWf"):
                 # Adjust rootinggdept
                 self.ActRootingDepth = self.CWf * (
-                    self.RootingDepth * self.LAI / max(0.001, self.MAXLAI)
+                    self.RootingDepth * self.LAI / pcr.max(0.001, self.MAXLAI)
                 ) + ((1 - self.CWf) * self.RootingDepth)
             else:
                 self.ActRootingDepth = self.RootingDepth
@@ -1419,7 +1420,7 @@ class WflowModel(DynamicModel):
             if self.MassWasting:
                 # Masswasting of dry snow
                 # 5.67 = tan 80 graden
-                SnowFluxFrac = min(0.5, self.Slope / 5.67) * min(
+                SnowFluxFrac = pcr.min(0.5, self.Slope / 5.67) * pcr.min(
                     1.0, self.Snow / MaxSnowPack
                 )
                 MaxFlux = SnowFluxFrac * self.Snow
@@ -1428,8 +1429,8 @@ class WflowModel(DynamicModel):
                 SnowFluxFrac = self.ZeroMap
                 MaxFlux = self.ZeroMap
 
-            self.SnowCover = ifthenelse(self.Snow > 0, scalar(1), scalar(0))
-            self.NrCell = areatotal(self.SnowCover, self.TopoId)
+            self.SnowCover = pcr.ifthenelse(self.Snow > 0, pcr.scalar(1), pcr.scalar(0))
+            self.NrCell = pcr.areatotal(self.SnowCover, self.TopoId)
 
             if hasattr(self, "GlacierFrac"):
                 """
@@ -1439,16 +1440,16 @@ class WflowModel(DynamicModel):
                 """
                 # TODO: document glacier module
                 self.snowdist = sCurve(self.Snow, a=8300.0, c=0.06)
-                self.Snow2Glacier = ifthenelse(
+                self.Snow2Glacier = pcr.ifthenelse(
                     self.Snow > 8300, self.snowdist * (self.Snow - 8300), self.ZeroMap
                 )
 
-                self.Snow2Glacier = ifthenelse(
+                self.Snow2Glacier = pcr.ifthenelse(
                     self.GlacierFrac > 0.0, self.Snow2Glacier, self.ZeroMap
                 )
                 # Max conversion to 8mm/day
                 self.Snow2Glacier = (
-                    min(self.Snow2Glacier, 8.0) * self.timestepsecs / self.basetimestep
+                    pcr.min(self.Snow2Glacier, 8.0) * self.timestepsecs / self.basetimestep
                 )
 
                 self.Snow = self.Snow - (self.Snow2Glacier * self.GlacierFrac)
@@ -1481,8 +1482,8 @@ class WflowModel(DynamicModel):
                 maxevap=self.PotEvap,
             )
 
-            self.PotTransSoil = cover(
-                max(0.0, self.PotEvap - self.Interception), 0.0
+            self.PotTransSoil = pcr.cover(
+                pcr.max(0.0, self.PotEvap - self.Interception), 0.0
             )  # now in mm
         else:
             NetInterception, self.ThroughFall, self.StemFlow, LeftOver, Interception, self.CanopyStorage = rainfall_interception_modrut(
@@ -1492,7 +1493,7 @@ class WflowModel(DynamicModel):
                 self.CanopyGapFraction,
                 self.Cmax,
             )
-            self.PotTransSoil = cover(max(0.0, LeftOver), 0.0)  # now in mm
+            self.PotTransSoil = pcr.cover(pcr.max(0.0, LeftOver), 0.0)  # now in mm
             self.Interception = NetInterception
 
         # Start with the soil calculations
@@ -1511,7 +1512,7 @@ class WflowModel(DynamicModel):
 
         # Runoff from water bodies and river network
         self.RunoffOpenWater = (
-            min(1.0, self.RiverFrac + self.WaterFrac) * self.AvailableForInfiltration
+            pcr.min(1.0, self.RiverFrac + self.WaterFrac) * self.AvailableForInfiltration
         )
         # self.RunoffOpenWater = self.ZeroMap
         self.AvailableForInfiltration = (
@@ -1523,7 +1524,7 @@ class WflowModel(DynamicModel):
             # Determine saturated fraction of cell
             self.SubCellFrac = sCurve(self.AbsoluteGW, c=self.CC, a=self.Altitude + 1.0)
             # Make sure total of SubCellFRac + WaterFRac + RiverFrac <=1 to avoid double counting
-            Frac_correction = ifthenelse(
+            Frac_correction = pcr.ifthenelse(
                 (self.SubCellFrac + self.RiverFrac + self.WaterFrac) > 1.0,
                 self.SubCellFrac + self.RiverFrac + self.WaterFrac - 1.0,
                 0.0,
@@ -1531,15 +1532,15 @@ class WflowModel(DynamicModel):
             self.SubCellRunoff = (
                 self.SubCellFrac - Frac_correction
             ) * self.AvailableForInfiltration
-            self.SubCellGWRunoff = min(
+            self.SubCellGWRunoff = pcr.min(
                 self.SubCellFrac * self.SatWaterDepth,
-                max(
+                pcr.max(
                     0.0,
                     self.SubCellFrac
                     * self.Slope
                     * self.KsatVer
                     * self.KsatHorFrac
-                    * exp(-self.f * self.zi),
+                    * pcr.exp(-self.f * self.zi),
                 ),
             )
             self.SatWaterDepth = self.SatWaterDepth - self.SubCellGWRunoff
@@ -1548,9 +1549,9 @@ class WflowModel(DynamicModel):
             )
         else:
             self.AbsoluteGW = self.DemMax - (self.zi * self.GWScale)
-            self.SubCellFrac = spatial(scalar(0.0))
-            self.SubCellGWRunoff = spatial(scalar(0.0))
-            self.SubCellRunoff = spatial(scalar(0.0))
+            self.SubCellFrac = pcr.spatial(pcr.scalar(0.0))
+            self.SubCellGWRunoff = pcr.spatial(pcr.scalar(0.0))
+            self.SubCellRunoff = pcr.spatial(pcr.scalar(0.0))
 
         # First determine if the soil infiltration capacity can deal with the
         # amount of water
@@ -1558,40 +1559,40 @@ class WflowModel(DynamicModel):
         SoilInf = self.AvailableForInfiltration * (1 - self.PathFrac)
         PathInf = self.AvailableForInfiltration * self.PathFrac
         if self.modelSnow:
-            # soilInfRedu = ifthenelse(self.TSoil < 0.0 , self.cf_soil, 1.0)
+            # soilInfRedu = pcr.ifthenelse(self.TSoil < 0.0 , self.cf_soil, 1.0)
             bb = 1.0 / (1.0 - self.cf_soil)
             soilInfRedu = sCurve(self.TSoil, a=self.ZeroMap, b=bb, c=8.0) + self.cf_soil
         else:
             soilInfRedu = 1.0
-        MaxInfiltSoil = min(self.InfiltCapSoil * soilInfRedu, SoilInf)
+        MaxInfiltSoil = pcr.min(self.InfiltCapSoil * soilInfRedu, SoilInf)
 
-        self.SoilInfiltExceeded = self.SoilInfiltExceeded + scalar(
+        self.SoilInfiltExceeded = self.SoilInfiltExceeded + pcr.scalar(
             self.InfiltCapSoil * soilInfRedu < SoilInf
         )
-        InfiltSoil = min(MaxInfiltSoil, UStoreCapacity)
+        InfiltSoil = pcr.min(MaxInfiltSoil, UStoreCapacity)
         self.UStoreDepth = self.UStoreDepth + InfiltSoil
         UStoreCapacity = UStoreCapacity - InfiltSoil
         self.AvailableForInfiltration = self.AvailableForInfiltration - InfiltSoil
 
-        MaxInfiltPath = min(self.InfiltCapPath * soilInfRedu, PathInf)
-        self.PathInfiltExceeded = self.PathInfiltExceeded + scalar(
+        MaxInfiltPath = pcr.min(self.InfiltCapPath * soilInfRedu, PathInf)
+        self.PathInfiltExceeded = self.PathInfiltExceeded + pcr.scalar(
             self.InfiltCapPath * soilInfRedu < PathInf
         )
-        InfiltPath = min(MaxInfiltPath, UStoreCapacity)
+        InfiltPath = pcr.min(MaxInfiltPath, UStoreCapacity)
         self.UStoreDepth = self.UStoreDepth + InfiltPath
         UStoreCapacity = UStoreCapacity - InfiltPath
         self.AvailableForInfiltration = self.AvailableForInfiltration - InfiltPath
 
         self.ActInfilt = InfiltPath + InfiltSoil
 
-        self.InfiltExcess = ifthenelse(
+        self.InfiltExcess = pcr.ifthenelse(
             UStoreCapacity > 0.0, self.AvailableForInfiltration, 0.0
         )
         self.ExcessWater = self.AvailableForInfiltration  # Saturation overland flow
         self.CumInfiltExcess = self.CumInfiltExcess + self.InfiltExcess
 
         # Limit rootingdepth (if set externally)
-        self.ActRootingDepth = min(self.SoilThickness * 0.99, self.ActRootingDepth)
+        self.ActRootingDepth = pcr.min(self.SoilThickness * 0.99, self.ActRootingDepth)
 
         # Determine transpiration
         # Split between bare soil/open water and vegetation
@@ -1604,16 +1605,16 @@ class WflowModel(DynamicModel):
         # Determine Open Water EVAP. Later subtract this from water that
         # enters the Kinematic wave
         self.RestEvap = self.potsoilopenwaterevap
-        self.ActEvapOpenWater = min(
+        self.ActEvapOpenWater = pcr.min(
             self.WaterLevel * 1000.0 * self.WaterFrac, self.WaterFrac * self.RestEvap
         )
         self.RestEvap = self.RestEvap - self.ActEvapOpenWater
 
         # Next the rest is used for soil evaporation
-        self.soilevap = self.RestEvap * max(
-            0.0, min(1.0, self.SaturationDeficit / self.SoilWaterCapacity)
+        self.soilevap = self.RestEvap * pcr.max(
+            0.0, pcr.min(1.0, self.SaturationDeficit / self.SoilWaterCapacity)
         )
-        self.soilevap = min(self.soilevap, self.UStoreDepth)
+        self.soilevap = pcr.min(self.soilevap, self.UStoreDepth)
         self.UStoreDepth = self.UStoreDepth - self.soilevap
 
         # rest is used for transpiration
@@ -1648,7 +1649,7 @@ class WflowModel(DynamicModel):
             else:
                 IRDemand = self.IrriDemandExternal
             # loop over irrigation areas and assign Q to linked river extraction points
-            self.Inflow = cover(IRDemand, self.Inflow)
+            self.Inflow = pcr.cover(IRDemand, self.Inflow)
 
         ##########################################################################
         # Transfer of water from unsaturated to saturated store...################
@@ -1663,28 +1664,28 @@ class WflowModel(DynamicModel):
 
         self.SaturationDeficit = self.SoilWaterCapacity - self.SatWaterDepth
 
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )  # Determine actual water depth
-        Ksat = self.KsatVer * exp(-self.f * self.zi)
+        Ksat = self.KsatVer * pcr.exp(-self.f * self.zi)
 
-        self.DeepKsat = self.KsatVer * exp(-self.f * self.SoilThickness)
+        self.DeepKsat = self.KsatVer * pcr.exp(-self.f * self.SoilThickness)
 
         # now the actual transfer to the saturated store..
-        self.Transfer = min(
+        self.Transfer = pcr.min(
             self.UStoreDepth,
-            ifthenelse(
+            pcr.ifthenelse(
                 self.SaturationDeficit <= 0.00001,
                 0.0,
                 Ksat * self.UStoreDepth / (self.SaturationDeficit + 1),
             ),
         )
 
-        MaxCapFlux = max(
-            0.0, min(Ksat, self.ActEvapUStore, UStoreCapacity, self.SatWaterDepth)
+        MaxCapFlux = pcr.max(
+            0.0, pcr.min(Ksat, self.ActEvapUStore, UStoreCapacity, self.SatWaterDepth)
         )
         # No capilary flux is roots are in water, max flux if very near to water, lower flux if distance is large
-        CapFluxScale = ifthenelse(
+        CapFluxScale = pcr.ifthenelse(
             self.zi > self.ActRootingDepth,
             self.CapScale
             / (self.CapScale + self.zi - self.ActRootingDepth)
@@ -1695,15 +1696,15 @@ class WflowModel(DynamicModel):
         self.CapFlux = MaxCapFlux * CapFluxScale
 
         # Determine Ksat at base
-        self.DeepTransfer = min(self.SatWaterDepth, self.DeepKsat)
+        self.DeepTransfer = pcr.min(self.SatWaterDepth, self.DeepKsat)
         # ActLeakage = 0.0
         # Now add leakage. to deeper groundwater
-        self.ActLeakage = cover(max(0.0, min(self.MaxLeakage, self.DeepTransfer)), 0)
-        self.Percolation = cover(
-            max(0.0, min(self.MaxPercolation, self.DeepTransfer)), 0
+        self.ActLeakage = pcr.cover(pcr.max(0.0, pcr.min(self.MaxLeakage, self.DeepTransfer)), 0)
+        self.Percolation = pcr.cover(
+            pcr.max(0.0, pcr.min(self.MaxPercolation, self.DeepTransfer)), 0
         )
 
-        # self.ActLeakage = ifthenelse(self.Seepage > 0.0, -1.0 * self.Seepage, self.ActLeakage)
+        # self.ActLeakage = pcr.ifthenelse(self.Seepage > 0.0, -1.0 * self.Seepage, self.ActLeakage)
         self.SatWaterDepth = (
             self.SatWaterDepth
             + self.Transfer
@@ -1714,16 +1715,16 @@ class WflowModel(DynamicModel):
         self.UStoreDepth = self.UStoreDepth - self.Transfer + self.CapFlux
 
         # Determine % saturated taking into account subcell fraction
-        self.Sat = max(
+        self.Sat = pcr.max(
             self.SubCellFrac,
-            scalar(self.SatWaterDepth >= (self.SoilWaterCapacity * 0.999)),
+            pcr.scalar(self.SatWaterDepth >= (self.SoilWaterCapacity * 0.999)),
         )
 
         ##########################################################################
         # Horizontal (downstream) transport of water #############################
         ##########################################################################
 
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )  # Determine actual water depth
 
@@ -1733,11 +1734,11 @@ class WflowModel(DynamicModel):
 
         # self.logger.debug("Waterdem set to Altitude....")
         self.WaterDem = self.Altitude - (self.zi * 0.001)
-        self.waterSlope = max(
-            0.000001, slope(self.WaterDem) * celllength() / self.reallength
+        self.waterSlope = pcr.max(
+            0.000001, pcr.slope(self.WaterDem) * pcr.celllength() / self.reallength
         )
         if self.waterdem:
-            self.waterLdd = lddcreate(self.WaterDem, 1e35, 1e35, 1e35, 1e35)
+            self.waterLdd = pcr.lddcreate(self.WaterDem, 1e35, 1e35, 1e35, 1e35)
 
         # TODO: We should make a couple ot iterations here...
         if self.waterdem:
@@ -1745,9 +1746,9 @@ class WflowModel(DynamicModel):
                 self.KsatVer
                 * self.KsatHorFrac
                 * self.waterSlope
-                * exp(-self.SaturationDeficit / self.M)
+                * pcr.exp(-self.SaturationDeficit / self.M)
             )
-            MaxHor = max(0.0, min(Lateral, self.SatWaterDepth))
+            MaxHor = pcr.max(0.0, pcr.min(Lateral, self.SatWaterDepth))
             self.SatWaterFlux = accucapacityflux(
                 self.waterLdd, self.SatWaterDepth, MaxHor
             )
@@ -1759,9 +1760,9 @@ class WflowModel(DynamicModel):
                 self.KsatVer
                 * self.KsatHorFrac
                 * self.waterSlope
-                * exp(-self.SaturationDeficit / self.M)
+                * pcr.exp(-self.SaturationDeficit / self.M)
             )
-            MaxHor = max(0.0, min(Lateral, self.SatWaterDepth))
+            MaxHor = pcr.max(0.0, pcr.min(Lateral, self.SatWaterDepth))
             # MaxHor = self.ZeroMap
             self.SatWaterFlux = accucapacityflux(
                 self.TopoLdd, self.SatWaterDepth, MaxHor
@@ -1783,13 +1784,13 @@ class WflowModel(DynamicModel):
         self.SatWaterDepth = self.SatWaterDepth - self.ExfiltWater
 
         # Re-determine UStoreCapacity
-        self.zi = max(
+        self.zi = pcr.max(
             0.0, self.SoilThickness - self.SatWaterDepth / (self.thetaS - self.thetaR)
         )  # Determine actual water depth
 
-        self.ExfiltFromUstore = ifthenelse(
+        self.ExfiltFromUstore = pcr.ifthenelse(
             self.zi == 0.0,
-            ifthenelse(self.UStoreDepth > 0.0, self.UStoreDepth, self.ZeroMap),
+            pcr.ifthenelse(self.UStoreDepth > 0.0, self.UStoreDepth, self.ZeroMap),
             self.ZeroMap,
         )
 
@@ -1797,7 +1798,7 @@ class WflowModel(DynamicModel):
         self.UStoreDepth = self.UStoreDepth - self.ExfiltFromUstore
         UStoreCapacity = self.SoilWaterCapacity - self.SatWaterDepth - self.UStoreDepth
 
-        Ksat = self.KsatVer * exp(-self.f * self.zi)
+        Ksat = self.KsatVer * pcr.exp(-self.f * self.zi)
 
         # Estimate water that may reinfilt
         SurfaceWater = self.WaterLevel / 1000.0  # SurfaceWater (mm)
@@ -1808,13 +1809,13 @@ class WflowModel(DynamicModel):
         # - self.MaxReinFilt: a map with reinfilt locations (usually the river mask) can be supplied)
         # - take into account that the river may not cover the whole cell
         if self.reInfilt:
-            self.reinfiltwater = min(
+            self.reinfiltwater = pcr.min(
                 self.MaxReinfilt,
-                max(
+                pcr.max(
                     0,
-                    min(
+                    pcr.min(
                         SurfaceWater * self.RiverWidth / self.reallength * 0.7,
-                        min(self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity),
+                        pcr.min(self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity),
                     ),
                 ),
             )
@@ -1835,7 +1836,7 @@ class WflowModel(DynamicModel):
                 - self.ActEvapOpenWater
             )
         else:
-            self.InwaterMM = max(
+            self.InwaterMM = pcr.max(
                 0.0,
                 self.ExfiltWater
                 + self.ExcessWater
@@ -1861,12 +1862,12 @@ class WflowModel(DynamicModel):
                 self.ReserVoirLocs,
                 timestepsecs=self.timestepsecs,
             )
-            self.OutflowDwn = upstream(
-                self.TopoLddOrg, cover(self.Outflow, scalar(0.0))
+            self.OutflowDwn = pcr.upstream(
+                self.TopoLddOrg, pcr.cover(self.Outflow, pcr.scalar(0.0))
             )
-            self.Inflow = self.OutflowDwn + cover(self.Inflow, self.ZeroMap)
+            self.Inflow = self.OutflowDwn + pcr.cover(self.Inflow, self.ZeroMap)
         else:
-            self.Inflow = cover(self.Inflow, self.ZeroMap)
+            self.Inflow = pcr.cover(self.Inflow, self.ZeroMap)
 
         self.ExfiltWaterCubic = self.ExfiltWater * self.ToCubic
         self.SubCellGWRunoffCubic = self.SubCellGWRunoff * self.ToCubic
@@ -1876,17 +1877,17 @@ class WflowModel(DynamicModel):
 
         # self.Inwater = self.Inwater + self.Inflow   # Add abstractions/inflows in m^3/sec
         # Check if we do not try to abstract more runoff then present
-        self.InflowKinWaveCell = upstream(
+        self.InflowKinWaveCell = pcr.upstream(
             self.TopoLdd, self.SurfaceRunoff
         )  # NG The extraction should be equal to the discharge upstream cell. You should not make the abstraction depended on the downstream cell, because they are correlated. During a stationary sum they will get equal to each other.
         MaxExtract = self.InflowKinWaveCell + self.Inwater  # NG
         # MaxExtract = self.SurfaceRunoff + self.Inwater
-        self.SurfaceWaterSupply = ifthenelse(
-            self.Inflow < 0.0, min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+        self.SurfaceWaterSupply = pcr.ifthenelse(
+            self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
         )
         self.OldSurfaceRunoff = self.SurfaceRunoff  # NG Store for iteration
         self.OldInwater = self.Inwater
-        self.Inwater = self.Inwater + ifthenelse(
+        self.Inwater = self.Inwater + pcr.ifthenelse(
             self.SurfaceWaterSupply > 0, -1.0 * self.SurfaceWaterSupply, self.Inflow
         )
 
@@ -1896,7 +1897,7 @@ class WflowModel(DynamicModel):
         # per distance along stream
         q = self.Inwater / self.DCL
         # discharge (m3/s)
-        self.SurfaceRunoff = kinematic(
+        self.SurfaceRunoff = pcr.kinematic(
             self.TopoLdd,
             self.SurfaceRunoff,
             q,
@@ -1911,21 +1912,21 @@ class WflowModel(DynamicModel):
         # at the flow in the upstream cell) and iterate if needed
         self.nrit = 0
         self.breakoff = 0.0001
-        if float(mapminimum(spatial(self.Inflow))) < 0.0:
+        if float(pcr.mapminimum(pcr.spatial(self.Inflow))) < 0.0:
             while True:
                 self.nrit += 1
                 oldsup = self.SurfaceWaterSupply
-                self.InflowKinWaveCell = upstream(self.TopoLdd, self.SurfaceRunoff)
+                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.SurfaceRunoff)
                 ##########################################################################
                 # Iterate to make a better estimation for the supply #####################
                 # (Runoff calculation via Kinematic wave) ################################
                 ##########################################################################
                 MaxExtract = self.InflowKinWaveCell + self.OldInwater
-                self.SurfaceWaterSupply = ifthenelse(
-                    self.Inflow < 0.0, min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+                self.SurfaceWaterSupply = pcr.ifthenelse(
+                    self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
                 )
                 # Fraction of demand that is not used but flows back into the river get fracttion and move to return locations
-                self.DemandReturnFlow = cover(
+                self.DemandReturnFlow = pcr.cover(
                     idtoid(
                         self.IrrigationSurfaceIntakes,
                         self.IrrigationSurfaceReturn,
@@ -1936,7 +1937,7 @@ class WflowModel(DynamicModel):
 
                 self.Inwater = (
                     self.OldInwater
-                    + ifthenelse(
+                    + pcr.ifthenelse(
                         self.SurfaceWaterSupply > 0,
                         -1.0 * self.SurfaceWaterSupply,
                         self.Inflow,
@@ -1946,7 +1947,7 @@ class WflowModel(DynamicModel):
                 # per distance along stream
                 q = self.Inwater / self.DCL
                 # discharge (m3/s)
-                self.SurfaceRunoff = kinematic(
+                self.SurfaceRunoff = pcr.kinematic(
                     self.TopoLdd,
                     self.OldSurfaceRunoff,
                     q,
@@ -1960,13 +1961,13 @@ class WflowModel(DynamicModel):
                     self.SurfaceRunoff * self.QMMConv
                 )  # SurfaceRunoffMM (mm) from SurfaceRunoff (m3/s)
 
-                self.InflowKinWaveCell = upstream(self.TopoLdd, self.OldSurfaceRunoff)
-                deltasup = float(mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
+                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.OldSurfaceRunoff)
+                deltasup = float(pcr.mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
 
                 if deltasup < self.breakoff or self.nrit >= self.maxitsupply:
                     break
 
-            self.InflowKinWaveCell = upstream(self.TopoLdd, self.SurfaceRunoff)
+            self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.SurfaceRunoff)
             self.updateRunOff()
         else:
             self.SurfaceRunoffMM = (
@@ -1982,11 +1983,11 @@ class WflowModel(DynamicModel):
                 self.IrrigationAreas,
                 self.SurfaceWaterSupply * (1 - self.DemandReturnFlowFraction),
             )
-            sqmarea = areatotal(
-                self.reallength * self.reallength, nominal(self.IrrigationAreas)
+            sqmarea = pcr.areatotal(
+                self.reallength * self.reallength, pcr.nominal(self.IrrigationAreas)
             )
 
-            self.IRSupplymm = cover(
+            self.IRSupplymm = pcr.cover(
                 IRSupplymm / (sqmarea / 1000.0 / self.timestepsecs), 0.0
             )
 
@@ -2005,26 +2006,26 @@ class WflowModel(DynamicModel):
         # first column (nr 1). Assumes that outputloc and columns match!
 
         if self.updating:
-            self.QM = timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            self.QM = pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
 
             # Now update the state. Just add to the Ustore
             # self.UStoreDepth =  result
             # No determine multiplication ratio for each gauge influence area.
             # For missing gauges 1.0 is assumed (no change).
-            # UpDiff = areamaximum(QM,  self.UpdateMap) - areamaximum(self.SurfaceRunoffMM, self.UpdateMap)
-            UpRatio = areamaximum(self.QM, self.UpdateMap) / areamaximum(
+            # UpDiff = pcr.areamaximum(QM,  self.UpdateMap) - pcr.areamaximum(self.SurfaceRunoffMM, self.UpdateMap)
+            UpRatio = pcr.areamaximum(self.QM, self.UpdateMap) / pcr.areamaximum(
                 self.SurfaceRunoffMM, self.UpdateMap
             )
 
-            UpRatio = cover(areaaverage(UpRatio, self.TopoId), 1.0)
+            UpRatio = pcr.cover(pcr.areaaverage(UpRatio, self.TopoId), 1.0)
             # Now split between Soil and Kyn  wave
-            self.UpRatioKyn = min(
+            self.UpRatioKyn = pcr.min(
                 self.MaxUpdMult,
-                max(self.MinUpdMult, (UpRatio - 1.0) * self.UpFrac + 1.0),
+                pcr.max(self.MinUpdMult, (UpRatio - 1.0) * self.UpFrac + 1.0),
             )
-            UpRatioSoil = min(
+            UpRatioSoil = pcr.min(
                 self.MaxUpdMult,
-                max(self.MinUpdMult, (UpRatio - 1.0) * (1.0 - self.UpFrac) + 1.0),
+                pcr.max(self.MinUpdMult, (UpRatio - 1.0) * (1.0 - self.UpFrac) + 1.0),
             )
 
             # update/nudge self.UStoreDepth for the whole upstream area,
@@ -2046,11 +2047,11 @@ class WflowModel(DynamicModel):
 
         # Determine Soil moisture profile
         # 1: average volumetric soil in total unsat store
-        self.SMVol = (cover(self.UStoreDepth / self.zi, 0.0) + self.thetaR) * (
+        self.SMVol = (pcr.cover(self.UStoreDepth / self.zi, 0.0) + self.thetaR) * (
             self.thetaS - self.thetaR
         )
         self.SMRootVol = (
-            cover(self.UStoreDepth / min(self.ActRootingDepth, self.zi), 0.0)
+            pcr.cover(self.UStoreDepth / pcr.min(self.ActRootingDepth, self.zi), 0.0)
             + self.thetaR
         ) * (self.thetaS - self.thetaR)
         # 2:
@@ -2059,22 +2060,22 @@ class WflowModel(DynamicModel):
         ##########################################################################
 
         self.QCatchmentMM = self.SurfaceRunoff * self.QMMConvUp
-        self.RunoffCoeff = cover(
+        self.RunoffCoeff = pcr.cover(
             self.QCatchmentMM
-            / catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd),
+            / pcr.catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd),
             self.ZeroMap,
         )
-        # self.AA = catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
-        # self.BB = catchmenttotal(cover(1.0), self.TopoLdd)
+        # self.AA = pcr.catchmenttotal(self.PrecipitationPlusMelt, self.TopoLdd)
+        # self.BB = pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
         # Single cell based water budget. snow not included yet.
 
         self.CellStorage = self.UStoreDepth + self.SatWaterDepth
         self.DeltaStorage = self.CellStorage - self.OrgStorage
         OutFlow = self.SatWaterFlux
         if self.waterdem:
-            CellInFlow = upstream(self.waterLdd, scalar(self.SatWaterFlux))
+            CellInFlow = pcr.upstream(self.waterLdd, pcr.scalar(self.SatWaterFlux))
         else:
-            CellInFlow = upstream(self.TopoLdd, scalar(self.SatWaterFlux))
+            CellInFlow = pcr.upstream(self.TopoLdd, pcr.scalar(self.SatWaterFlux))
 
         self.CumOutFlow = self.CumOutFlow + OutFlow
         self.CumActInfilt = self.CumActInfilt + self.ActInfilt
@@ -2086,7 +2087,7 @@ class WflowModel(DynamicModel):
 
         self.CumInt = self.CumInt + self.Interception
 
-        self.SnowCover = ifthenelse(self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap)
+        self.SnowCover = pcr.ifthenelse(self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap)
         self.CumLeakage = self.CumLeakage + self.ActLeakage
         self.CumInwaterMM = self.CumInwaterMM + self.InwaterMM
         self.CumExfiltWater = self.CumExfiltWater + self.ExfiltWater

--- a/wflow/wflow_sbm_old.py
+++ b/wflow/wflow_sbm_old.py
@@ -892,7 +892,10 @@ class WflowModel(pcraster.framework.DynamicModel):
                 )
                 self.TopoLddOrg = self.TopoLdd
                 self.TopoLdd = pcr.lddrepair(
-                    pcr.cover(pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)), self.TopoLdd)
+                    pcr.cover(
+                        pcr.ifthen(pcr.boolean(self.ReserVoirLocs), pcr.ldd(5)),
+                        self.TopoLdd,
+                    )
                 )
         else:
             self.nrres = 0
@@ -1029,7 +1032,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0)))
+            ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
@@ -1107,7 +1111,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
             ds = pcr.downstream(self.TopoLdd, self.TopoId)
             usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
+            self.TopoLdd = pcr.lddrepair(
+                pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd)
+            )
 
         # Used to seperate output per LandUse/management classes
         OutZones = self.LandUse
@@ -1165,7 +1171,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Aspect = pcr.ifthenelse(self.Aspect <= 0.0, pcr.scalar(0.001), self.Aspect)
         # On Flat areas the Aspect function fails, fill in with average...
         self.Aspect = pcr.ifthenelse(
-            pcr.defined(self.Aspect), self.Aspect, pcr.areaaverage(self.Aspect, self.TopoId)
+            pcr.defined(self.Aspect),
+            self.Aspect,
+            pcr.areaaverage(self.Aspect, self.TopoId),
         )
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
         drainlength = detdrainlength(self.TopoLdd, self.xl, self.yl)
@@ -1378,7 +1386,10 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.Ewet = (1 - pcr.exp(-self.Kext * self.LAI)) * self.PotenEvap
             self.EoverR = pcr.ifthenelse(
                 self.Precipitation > 0.0,
-                pcr.min(0.25, pcr.cover(self.Ewet / pcr.max(0.0001, self.Precipitation), 0.0)),
+                pcr.min(
+                    0.25,
+                    pcr.cover(self.Ewet / pcr.max(0.0001, self.Precipitation), 0.0),
+                ),
                 0.0,
             )
             if hasattr(self, "MAXLAI") and hasattr(self, "CWf"):
@@ -1449,7 +1460,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                 )
                 # Max conversion to 8mm/day
                 self.Snow2Glacier = (
-                    pcr.min(self.Snow2Glacier, 8.0) * self.timestepsecs / self.basetimestep
+                    pcr.min(self.Snow2Glacier, 8.0)
+                    * self.timestepsecs
+                    / self.basetimestep
                 )
 
                 self.Snow = self.Snow - (self.Snow2Glacier * self.GlacierFrac)
@@ -1512,7 +1525,8 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         # Runoff from water bodies and river network
         self.RunoffOpenWater = (
-            pcr.min(1.0, self.RiverFrac + self.WaterFrac) * self.AvailableForInfiltration
+            pcr.min(1.0, self.RiverFrac + self.WaterFrac)
+            * self.AvailableForInfiltration
         )
         # self.RunoffOpenWater = self.ZeroMap
         self.AvailableForInfiltration = (
@@ -1699,7 +1713,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.DeepTransfer = pcr.min(self.SatWaterDepth, self.DeepKsat)
         # ActLeakage = 0.0
         # Now add leakage. to deeper groundwater
-        self.ActLeakage = pcr.cover(pcr.max(0.0, pcr.min(self.MaxLeakage, self.DeepTransfer)), 0)
+        self.ActLeakage = pcr.cover(
+            pcr.max(0.0, pcr.min(self.MaxLeakage, self.DeepTransfer)), 0
+        )
         self.Percolation = pcr.cover(
             pcr.max(0.0, pcr.min(self.MaxPercolation, self.DeepTransfer)), 0
         )
@@ -1815,7 +1831,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                     0,
                     pcr.min(
                         SurfaceWater * self.RiverWidth / self.reallength * 0.7,
-                        pcr.min(self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity),
+                        pcr.min(
+                            self.InfiltCapSoil * (1.0 - self.PathFrac), UStoreCapacity
+                        ),
                     ),
                 ),
             )
@@ -1923,7 +1941,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                 ##########################################################################
                 MaxExtract = self.InflowKinWaveCell + self.OldInwater
                 self.SurfaceWaterSupply = pcr.ifthenelse(
-                    self.Inflow < 0.0, pcr.min(MaxExtract, -1.0 * self.Inflow), self.ZeroMap
+                    self.Inflow < 0.0,
+                    pcr.min(MaxExtract, -1.0 * self.Inflow),
+                    self.ZeroMap,
                 )
                 # Fraction of demand that is not used but flows back into the river get fracttion and move to return locations
                 self.DemandReturnFlow = pcr.cover(
@@ -1961,7 +1981,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                     self.SurfaceRunoff * self.QMMConv
                 )  # SurfaceRunoffMM (mm) from SurfaceRunoff (m3/s)
 
-                self.InflowKinWaveCell = pcr.upstream(self.TopoLdd, self.OldSurfaceRunoff)
+                self.InflowKinWaveCell = pcr.upstream(
+                    self.TopoLdd, self.OldSurfaceRunoff
+                )
                 deltasup = float(pcr.mapmaximum(abs(oldsup - self.SurfaceWaterSupply)))
 
                 if deltasup < self.breakoff or self.nrit >= self.maxitsupply:
@@ -2006,7 +2028,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # first column (nr 1). Assumes that outputloc and columns match!
 
         if self.updating:
-            self.QM = pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            self.QM = (
+                pcr.timeinputscalar(self.updateFile, self.UpdateMap) * self.QMMConv
+            )
 
             # Now update the state. Just add to the Ustore
             # self.UStoreDepth =  result
@@ -2087,7 +2111,9 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         self.CumInt = self.CumInt + self.Interception
 
-        self.SnowCover = pcr.ifthenelse(self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap)
+        self.SnowCover = pcr.ifthenelse(
+            self.Snow > 0.0, self.ZeroMap + 1.0, self.ZeroMap
+        )
         self.CumLeakage = self.CumLeakage + self.ActLeakage
         self.CumInwaterMM = self.CumInwaterMM + self.InwaterMM
         self.CumExfiltWater = self.CumExfiltWater + self.ExfiltWater

--- a/wflow/wflow_sceleton.py
+++ b/wflow/wflow_sceleton.py
@@ -18,6 +18,7 @@ wflow_sceleton  -C case -R Runid -c inifile
 
 """
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -30,7 +31,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. This is your work!
   """
@@ -43,8 +44,8 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
       
       """
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -166,7 +167,7 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
         self.timestepsecs = int(
             configget(self.config, "model", "timestepsecs", "86400")
@@ -192,14 +193,14 @@ class WflowModel(DynamicModel):
         if self.reinit:
             self.logger.warning("Setting initial states to default")
             for s in self.stateVariables():
-                exec("self." + s + " = cover(1.0)")
+                exec("self." + s + " = pcr.cover(1.0)")
         else:
             try:
                 self.wf_resume(self.Dir + "/instate/")
             except:
                 self.logger.warning("Cannot load initial states, setting to default")
                 for s in self.stateVariables():
-                    exec("self." + s + " = cover(1.0)")
+                    exec("self." + s + " = pcr.cover(1.0)")
 
     def default_summarymaps(self):
         """

--- a/wflow/wflow_sceleton.py
+++ b/wflow/wflow_sceleton.py
@@ -18,12 +18,8 @@ wflow_sceleton  -C case -R Runid -c inifile
 
 """
 
-import getopt
-
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-
-# import scipy
 
 
 def usage(*args):

--- a/wflow/wflow_snow.py
+++ b/wflow/wflow_snow.py
@@ -177,7 +177,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             rest = pcr.cover(pcr.readmap(mapname), default)
         else:
             if os.path.isfile(pathtotbl):
-                rest = pcr.cover(pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default)
+                rest = pcr.cover(
+                    pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default
+                )
                 self.logger.info("Creating map from table: " + pathtotbl)
             else:
                 self.logger.warning(
@@ -474,7 +476,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         RainFrac = pcr.ifthenelse(
             1.0 * self.TTI == 0.0,
             pcr.ifthenelse(Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)),
-            pcr.min((Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, pcr.scalar(1.0)),
+            pcr.min(
+                (Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, pcr.scalar(1.0)
+            ),
         )
         RainFrac = pcr.max(
             RainFrac, pcr.scalar(0.0)

--- a/wflow/wflow_snow.py
+++ b/wflow/wflow_snow.py
@@ -58,6 +58,7 @@ wflow_snow [-h][-v level][-F runinfofile][-L logfile][-C casename][-R runId]
 import getopt
 import os.path
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 
 wflow = "wflow_pack: "
@@ -91,10 +92,10 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     def __init__(self, cloneMap, Dir, RunDir, configfile):
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -173,10 +174,10 @@ class WflowModel(DynamicModel):
         )
         if os.path.exists(mapname):
             self.logger.info("reading map parameter file: " + mapname)
-            rest = cover(readmap(mapname), default)
+            rest = pcr.cover(pcr.readmap(mapname), default)
         else:
             if os.path.isfile(pathtotbl):
-                rest = cover(lookupscalar(pathtotbl, landuse, subcatch, soil), default)
+                rest = pcr.cover(pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default)
                 self.logger.info("Creating map from table: " + pathtotbl)
             else:
                 self.logger.warning(
@@ -185,7 +186,7 @@ class WflowModel(DynamicModel):
                     + ") returning default value: "
                     + str(default)
                 )
-                rest = scalar(default)
+                rest = pcr.scalar(default)
 
         return rest
 
@@ -202,8 +203,8 @@ class WflowModel(DynamicModel):
             self.logger.info("Saving initial conditions over start conditions...")
             self.wf_suspend(self.SaveDir + "/instate/")
 
-        report(self.sumprecip, self.SaveDir + "/outsum/sumprecip.map")
-        report(self.sumtemp, self.SaveDir + "/outsum/sumtemp.map")
+        pcr.report(self.sumprecip, self.SaveDir + "/outsum/sumprecip.map")
+        pcr.report(self.sumtemp, self.SaveDir + "/outsum/sumtemp.map")
 
     def initial(self):
 
@@ -214,9 +215,9 @@ class WflowModel(DynamicModel):
     """
         global statistics
 
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
-        self.thestep = scalar(0)
+        self.thestep = pcr.scalar(0)
         self.setQuiet(True)
         self.precipTss = (
             "../intss/P.tss"
@@ -246,33 +247,33 @@ class WflowModel(DynamicModel):
         self.TEMP_style = int(configget(self.config, "model", "TEMP_style", "1"))
 
         # 2: Input base maps ########################################################
-        subcatch = ordinal(
-            readmap(self.Dir + "/staticmaps/wflow_subcatch.map")
+        subcatch = pcr.ordinal(
+            pcr.readmap(self.Dir + "/staticmaps/wflow_subcatch.map")
         )  # Determines the area of calculations (all cells > 0)
-        subcatch = ifthen(subcatch > 0, subcatch)
+        subcatch = pcr.ifthen(subcatch > 0, subcatch)
         if self.sCatch > 0:
-            subcatch = ifthen(subcatch == sCatch, subcatch)
+            subcatch = pcr.ifthen(subcatch == sCatch, subcatch)
 
-        self.Altitude = readmap(self.Dir + "/staticmaps/wflow_dem") * scalar(
-            defined(subcatch)
+        self.Altitude = pcr.readmap(self.Dir + "/staticmaps/wflow_dem") * pcr.scalar(
+            pcr.defined(subcatch)
         )  #: The digital elevation map (DEM)
-        self.TopoId = readmap(
+        self.TopoId = pcr.readmap(
             self.Dir + "/staticmaps/wflow_subcatch.map"
         )  #: Map define the area over which the calculations are done (mask)
-        self.TopoLdd = readmap(
+        self.TopoLdd = pcr.readmap(
             self.Dir + "/staticmaps/wflow_ldd.map"
         )  #: The local drinage definition map (ldd)
         # read landuse and soilmap and make sure there are no missing points related to the
         # subcatchment map. Currently sets the lu and soil type  type to 1
-        self.LandUse = readmap(
+        self.LandUse = pcr.readmap(
             self.Dir + "/staticmaps/wflow_landuse.map"
         )  #: Map with lan-use/cover classes
-        self.LandUse = cover(self.LandUse, nominal(ordinal(subcatch) > 0))
-        self.Soil = readmap(
+        self.LandUse = pcr.cover(self.LandUse, pcr.nominal(pcr.ordinal(subcatch) > 0))
+        self.Soil = pcr.readmap(
             self.Dir + "/staticmaps/wflow_soil.map"
         )  #: Map with soil classes
-        self.Soil = cover(self.Soil, nominal(ordinal(subcatch) > 0))
-        self.OutputLoc = readmap(
+        self.Soil = pcr.cover(self.Soil, pcr.nominal(pcr.ordinal(subcatch) > 0))
+        self.OutputLoc = pcr.readmap(
             self.Dir + "/staticmaps/wflow_gauges.map"
         )  #: Map with locations of output gauge(s)
 
@@ -282,14 +283,14 @@ class WflowModel(DynamicModel):
         )
 
         if self.scalarInput:
-            self.gaugesMap = readmap(
+            self.gaugesMap = pcr.readmap(
                 self.Dir + "/staticmaps/wflow_mgauges.map"
             )  #: Map with locations of rainfall/evap/temp gauge(s). Only needed if the input to the model is not in maps
-        self.OutputId = readmap(
+        self.OutputId = pcr.readmap(
             self.Dir + "/staticmaps/wflow_subcatch.map"
         )  # location of subcatchment
 
-        self.ZeroMap = 0.0 * scalar(subcatch)  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(subcatch)  # map with only zero's
 
         # 3: Input time series ###################################################
         self.Rain_ = self.Dir + "/inmaps/P"  #: timeseries for rainfall
@@ -297,8 +298,8 @@ class WflowModel(DynamicModel):
 
         # Set static initial values here #########################################
 
-        self.Latitude = ycoordinate(boolean(self.Altitude))
-        self.Longitude = xcoordinate(boolean(self.Altitude))
+        self.Latitude = pcr.ycoordinate(pcr.boolean(self.Altitude))
+        self.Longitude = pcr.xcoordinate(pcr.boolean(self.Altitude))
 
         self.logger.info("Linking parameters to landuse, catchment and soil...")
 
@@ -379,10 +380,10 @@ class WflowModel(DynamicModel):
         self.xl, self.yl, self.reallength = pcrut.detRealCellLength(
             self.ZeroMap, sizeinmetres
         )
-        self.Slope = slope(self.Altitude)
-        self.Slope = ifthen(
-            boolean(self.TopoId),
-            max(0.001, self.Slope * celllength() / self.reallength),
+        self.Slope = pcr.slope(self.Altitude)
+        self.Slope = pcr.ifthen(
+            pcr.boolean(self.TopoId),
+            pcr.max(0.001, self.Slope * pcr.celllength() / self.reallength),
         )
 
         # Multiply parameters with a factor (for calibration etc) -P option in command line
@@ -395,13 +396,13 @@ class WflowModel(DynamicModel):
 
         # Initializing of variables
         self.logger.info("Initializing of model variables..")
-        self.TopoLdd = lddmask(self.TopoLdd, boolean(self.TopoId))
-        catchmentcells = maptotal(scalar(self.TopoId))
+        self.TopoLdd = pcr.lddmask(self.TopoLdd, pcr.boolean(self.TopoId))
+        catchmentcells = pcr.maptotal(pcr.scalar(self.TopoId))
 
         # Used to seperate output per LandUse/management classes
         # OutZones = self.LandUse
-        # report(self.reallength,"rl.map")
-        # report(catchmentcells,"kk.map")
+        # pcr.report(self.reallength,"rl.map")
+        # pcr.report(catchmentcells,"kk.map")
         self.QMMConv = self.timestepsecs / (
             self.reallength * self.reallength * 0.001
         )  # m3/s --> mm
@@ -414,13 +415,13 @@ class WflowModel(DynamicModel):
 
         # Save some summary maps
         self.logger.info("Saving summary maps...")
-        report(self.Cfmax, self.Dir + "/" + self.runId + "/outsum/Cfmax.map")
-        report(self.TTI, self.Dir + "/" + self.runId + "/outsum/TTI.map")
-        report(self.TT, self.Dir + "/" + self.runId + "/outsum/TT.map")
-        report(self.WHC, self.Dir + "/" + self.runId + "/outsum/WHC.map")
-        report(self.xl, self.Dir + "/" + self.runId + "/outsum/xl.map")
-        report(self.yl, self.Dir + "/" + self.runId + "/outsum/yl.map")
-        report(self.reallength, self.Dir + "/" + self.runId + "/outsum/rl.map")
+        pcr.report(self.Cfmax, self.Dir + "/" + self.runId + "/outsum/Cfmax.map")
+        pcr.report(self.TTI, self.Dir + "/" + self.runId + "/outsum/TTI.map")
+        pcr.report(self.TT, self.Dir + "/" + self.runId + "/outsum/TT.map")
+        pcr.report(self.WHC, self.Dir + "/" + self.runId + "/outsum/WHC.map")
+        pcr.report(self.xl, self.Dir + "/" + self.runId + "/outsum/xl.map")
+        pcr.report(self.yl, self.Dir + "/" + self.runId + "/outsum/yl.map")
+        pcr.report(self.reallength, self.Dir + "/" + self.runId + "/outsum/rl.map")
 
         self.SaveDir = self.Dir + "/" + self.runId + "/"
         self.logger.info("Starting Dynamic run...")
@@ -430,8 +431,8 @@ class WflowModel(DynamicModel):
 
         if self.reinit == 1:
             self.logger.info("Setting initial conditions to default (zero!)")
-            self.FreeWater = cover(0.0)  #: Water on surface (state variable [mm])
-            self.DrySnow = cover(0.0)  #: Snow amount (state variable [mm])
+            self.FreeWater = pcr.cover(0.0)  #: Water on surface (state variable [mm])
+            self.DrySnow = pcr.cover(0.0)  #: Snow amount (state variable [mm])
         else:
             self.wf_resume(self.Dir + "/instate/")
 
@@ -448,20 +449,20 @@ class WflowModel(DynamicModel):
         if self.scalarInput:
             # gaugesmap not yet finished. Should be a map with cells that
             # hold the gauges with an unique id
-            Precipitation = timeinputscalar(self.precipTss, self.gaugesMap)
-            # Seepage = cover(timeinputscalar(self.SeepageTss,self.SeepageLoc),0)
+            Precipitation = pcr.timeinputscalar(self.precipTss, self.gaugesMap)
+            # Seepage = pcr.cover(pcr.timeinputscalar(self.SeepageTss,self.SeepageLoc),0)
             Precipitation = pcrut.interpolategauges(Precipitation, self.interpolMethod)
             # self.report(PotEvaporation,'p')
-            Temperature = timeinputscalar(self.tempTss, self.gaugesMap)
+            Temperature = pcr.timeinputscalar(self.tempTss, self.gaugesMap)
             Temperature = pcrut.interpolategauges(Temperature, self.interpolMethod)
             Temperature = Temperature + self.TempCor
         else:
-            Precipitation = cover(self.readmap(self.Rain_, 0.0, self.P_style), 0.0)
-            # Inflow=cover(self.readmap(self.Inflow),0)
+            Precipitation = pcr.cover(self.readmap(self.Rain_, 0.0, self.P_style), 0.0)
+            # Inflow=pcr.cover(self.readmap(self.Inflow),0)
             # These ar ALWAYS 0 at present!!!
             Temperature = self.readmap(self.Temp_, 0.0, self.TEMP_style)
             Temperature = Temperature + self.TempCor
-            # Inflow=spatial(scalar(0.0))
+            # Inflow=pcr.spatial(pcr.scalar(0.0))
 
         # Multiply input parameters with a factor (for calibration etc) -p option in command line
         for k, v in multdynapars.items():
@@ -470,13 +471,13 @@ class WflowModel(DynamicModel):
             exec(estr)
 
         # Snow pack modelling degree day methods
-        RainFrac = ifthenelse(
+        RainFrac = pcr.ifthenelse(
             1.0 * self.TTI == 0.0,
-            ifthenelse(Temperature <= self.TT, scalar(0.0), scalar(1.0)),
-            min((Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, scalar(1.0)),
+            pcr.ifthenelse(Temperature <= self.TT, pcr.scalar(0.0), pcr.scalar(1.0)),
+            pcr.min((Temperature - (self.TT - self.TTI / 2.0)) / self.TTI, pcr.scalar(1.0)),
         )
-        RainFrac = max(
-            RainFrac, scalar(0.0)
+        RainFrac = pcr.max(
+            RainFrac, pcr.scalar(0.0)
         )  # fraction of precipitation which falls as rain
         SnowFrac = 1.0 - RainFrac  # fraction of precipitation which falls as snow
         Precipitation = (
@@ -485,26 +486,26 @@ class WflowModel(DynamicModel):
 
         SnowFall = SnowFrac * Precipitation  #: snowfall depth
         RainFall = RainFrac * Precipitation  #: rainfall depth
-        PotSnowMelt = ifthenelse(
-            Temperature > self.TT, self.Cfmax * (Temperature - self.TT), scalar(0.0)
+        PotSnowMelt = pcr.ifthenelse(
+            Temperature > self.TT, self.Cfmax * (Temperature - self.TT), pcr.scalar(0.0)
         )  # Potential snow melt, based on temperature
-        PotRefreezing = ifthenelse(
+        PotRefreezing = pcr.ifthenelse(
             Temperature < self.TT, self.Cfmax * self.CFR * (self.TT - Temperature), 0.0
         )  # Potential refreezing, based on temperature
 
         # PotSnowMelt=self.FoCfmax*PotSnowMelt     	#correction for forest zones 0.6)
         # PotRefreezing=self.FoCfmax*PotRefreezing
-        Refreezing = ifthenelse(
-            Temperature < self.TT, min(PotRefreezing, self.FreeWater), 0.0
+        Refreezing = pcr.ifthenelse(
+            Temperature < self.TT, pcr.min(PotRefreezing, self.FreeWater), 0.0
         )  # actual refreezing
-        SnowMelt = min(PotSnowMelt, self.DrySnow)  # actual snow melt
+        SnowMelt = pcr.min(PotSnowMelt, self.DrySnow)  # actual snow melt
         self.DrySnow = (
             self.DrySnow + SnowFall + Refreezing - SnowMelt
         )  # dry snow content
         self.FreeWater = self.FreeWater - Refreezing  # free water content in snow
         MaxFreeWater = self.DrySnow * self.WHC
         self.FreeWater = self.FreeWater + SnowMelt + RainFall
-        InSoil = max(
+        InSoil = pcr.max(
             self.FreeWater - MaxFreeWater, 0.0
         )  # abundant water in snow pack which goes into soil
         self.FreeWater = self.FreeWater - InSoil
@@ -514,7 +515,7 @@ class WflowModel(DynamicModel):
         if self.MassWasting:
             # Masswasting of snow
             # 5.67 = tan 80 graden
-            SnowFluxFrac = min(0.5, self.Slope / 5.67) * min(
+            SnowFluxFrac = pcr.min(0.5, self.Slope / 5.67) * pcr.min(
                 1.0, self.DrySnow / MaxSnowPack
             )
             MaxFlux = SnowFluxFrac * self.DrySnow

--- a/wflow/wflow_snow.py
+++ b/wflow/wflow_snow.py
@@ -55,13 +55,10 @@ wflow_snow [-h][-v level][-F runinfofile][-L logfile][-C casename][-R runId]
     
 """
 
-
-import os
-import os.path
 import getopt
-from wflow.wf_DynamicFramework import *
-import wflow.pcrut as pcrut
+import os.path
 
+from wflow.wf_DynamicFramework import *
 
 wflow = "wflow_pack: "
 wflowVersion = (

--- a/wflow/wflow_sphy.py
+++ b/wflow/wflow_sphy.py
@@ -515,7 +515,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             for i in pars:
                 try:
                     setattr(
-                        self, i, pcr.readmap(self.inpath + config.get("GROUNDW_PARS", i))
+                        self,
+                        i,
+                        pcr.readmap(self.inpath + config.get("GROUNDW_PARS", i)),
                     )
                 except:
                     setattr(
@@ -605,7 +607,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             pars = ["DDFG", "DDFDG", "GlacF"]
             for i in pars:
                 try:
-                    setattr(self, i, pcr.readmap(self.inpath + config.get("GLACIER", i)))
+                    setattr(
+                        self, i, pcr.readmap(self.inpath + config.get("GLACIER", i))
+                    )
                 except:
                     # setattr(self, i, config.getfloat('GLACIER',i))
                     setattr(self, i, float(configget(self.config, "GLACIER", i, i)))
@@ -686,7 +690,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         # -read lake maps and parameters if lake module is used
         if self.LakeFLAG == 1:
             # nominal map with lake IDs
-            self.LakeID = pcr.cover(pcr.readmap(self.inpath + config.get("LAKE", "LakeId")), 0)
+            self.LakeID = pcr.cover(
+                pcr.readmap(self.inpath + config.get("LAKE", "LakeId")), 0
+            )
             # lookup table with function for each lake (exp, 1-order poly, 2-order poly, 3-order poly)
             LakeFunc_Tab = self.inpath + config.get("LAKE", "LakeFunc")
             # lookup table with Qh-coeficients for each lake
@@ -945,7 +951,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             if self.LakeFLAG == 1:
                 LakeStor_Tab = self.inpath + config.get("LAKE", "LakeStor")
                 self.StorRES = (
-                    pcr.cover(pcr.lookupscalar(LakeStor_Tab, 1, self.LakeID), 0) * 10 ** 6
+                    pcr.cover(pcr.lookupscalar(LakeStor_Tab, 1, self.LakeID), 0)
+                    * 10 ** 6
                 )  # convert to m3
                 # -Qfrac for lake cells should be zero, else 1
                 self.QFRAC = pcr.ifthenelse(self.LakeID != 0, pcr.scalar(0), 1)
@@ -957,7 +964,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                 try:
                     self.StorRES = self.StorRES + ResStor
                     # -Qfrac for reservoir cells should be zero, else 1
-                    self.QFRAC = pcr.ifthenelse(self.ResID != 0, pcr.scalar(0), self.QFRAC)
+                    self.QFRAC = pcr.ifthenelse(
+                        self.ResID != 0, pcr.scalar(0), self.QFRAC
+                    )
                 except:
                     self.StorRES = ResStor
                     # -Qfrac for reservoir cells should be zero, else 1
@@ -975,7 +984,8 @@ class WflowModel(pcraster.framework.DynamicModel):
                         i + "stor",
                         (
                             pcr.cover(
-                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
+                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID),
+                                0,
                             )
                             + pcr.cover(
                                 pcr.lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
@@ -993,7 +1003,8 @@ class WflowModel(pcraster.framework.DynamicModel):
                             self,
                             i + "stor",
                             pcr.cover(
-                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
+                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID),
+                                0,
                             )
                             * 10 ** 6,
                         )
@@ -1007,7 +1018,10 @@ class WflowModel(pcraster.framework.DynamicModel):
                                 self,
                                 i + "stor",
                                 pcr.cover(
-                                    pcr.lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
+                                    pcr.lookupscalar(
+                                        ResStor_Tab, column + 3, self.ResID
+                                    ),
+                                    0,
                                 )
                                 * 10 ** 6,
                             )
@@ -1743,7 +1757,10 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.RootWater = self.RootWater - RootRunoff
         # -Actual evapotranspiration
         etreddry = pcr.max(
-            pcr.min((self.RootWater - self.RootDry) / (self.RootWilt - self.RootDry), 1), 0
+            pcr.min(
+                (self.RootWater - self.RootDry) / (self.RootWilt - self.RootDry), 1
+            ),
+            0,
         )
         ETact = self.ET.ETact(
             pcr, ETpot, self.RootWater, self.RootSat, etreddry, RainFrac
@@ -1758,7 +1775,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
         ):
             self.ETaSubBasinTSS.sample(
-                pcr.catchmenttotal(ActETact, self.FlowDir) / pcr.catchmenttotal(1, self.FlowDir)
+                pcr.catchmenttotal(ActETact, self.FlowDir)
+                / pcr.catchmenttotal(1, self.FlowDir)
             )
         # -Update rootwater content
         self.RootWater = pcr.max(self.RootWater - ETact, 0)
@@ -1796,7 +1814,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                     self.SeePage = self.SeepOld
             # -Report seepage
             self.reporting.reporting(self, pcr, "TotSeepF", pcr.scalar(self.SeePage))
-            self.SubWater = pcr.min(pcr.max(self.SubWater - self.SeePage, 0), self.SubSat)
+            self.SubWater = pcr.min(
+                pcr.max(self.SubWater - self.SeePage, 0), self.SubSat
+            )
             if self.mm_rep_FLAG == 1 and (
                 self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
             ):
@@ -1985,7 +2005,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             # -report flux in mm
             if self.mm_rep_FLAG == 1:
                 self.QTOTSubBasinTSS.sample(
-                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)) * 1000
+                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir))
+                    * 1000
                 )
             # -report lake and reservoir waterbalance
             if self.LakeFLAG == 1 and config.getint("REPORTING", "Lake_wbal") == 1:
@@ -2153,7 +2174,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.reporting.reporting(self, pcr, "QallRAtot", Q)
             if self.mm_rep_FLAG == 1:
                 self.QTOTSubBasinTSS.sample(
-                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)) * 1000
+                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir))
+                    * 1000
                 )
             # -Snow routing
             if self.SnowRA_FLAG == 1 and self.SnowFLAG == 1:

--- a/wflow/wflow_sphy.py
+++ b/wflow/wflow_sphy.py
@@ -19,23 +19,11 @@
 # TODO: split off routing
 
 
-import sys
-import os
 import os.path
-import getopt
-import datetime as dt
 
-from wflow.wf_DynamicFramework import *
-from wflow.wf_DynamicFramework import *
-from wflow.wflow_adapt import *
-from wflow.wflow_adapt import *
 import pcraster as pcr
-
-# from wflow.wflow_lib import reporting
-
-# import scipy
-# import pcrut
-
+from wflow.wf_DynamicFramework import *
+from wflow.wflow_adapt import *
 
 wflow = "wflow_sphy"
 

--- a/wflow/wflow_sphy.py
+++ b/wflow/wflow_sphy.py
@@ -22,6 +22,7 @@
 import os.path
 
 import pcraster as pcr
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -46,7 +47,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
 
     """
   The user defined model class.
@@ -54,10 +55,10 @@ class WflowModel(DynamicModel):
   """
 
     def __init__(self, cloneMap, Dir, RunDir, configfile):
-        DynamicModel.__init__(self)
+        pcraster.framework.DynamicModel.__init__(self)
         self.caseName = os.path.abspath(Dir)
         self.clonemappath = os.path.join(os.path.abspath(Dir), "staticmaps", cloneMap)
-        setclone(self.clonemappath)
+        pcr.setclone(self.clonemappath)
         self.runId = RunDir
         self.Dir = os.path.abspath(Dir)
         self.configfile = configfile
@@ -219,9 +220,9 @@ class WflowModel(DynamicModel):
         global multpars
         global updateCols
 
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
-        self.thestep = scalar(0)
+        self.thestep = pcr.scalar(0)
 
         #: files to be used in case of timesries (scalar) input to the model
 
@@ -375,7 +376,7 @@ class WflowModel(DynamicModel):
         # self.startdateF = self.datetime.datetime(syF, smF, sdF)
 
         # -set the global options
-        setglobaloption("radians")
+        pcr.setglobaloption("radians")
         # -set the 2000 julian date number
         self.julian_date_2000 = 2451545
         # -set the option to calculate the fluxes in mm for the upstream area
@@ -383,25 +384,25 @@ class WflowModel(DynamicModel):
 
         # #-setting clone map
         # clonemap = self.inpath + config.get('GENERAL','mask')  ##->check
-        # setclone(clonemap)
-        # self.clone = readmap(clonemap)
+        # pcr.setclone(clonemap)
+        # self.clone = pcr.readmap(clonemap)
 
         # -read general maps
-        self.DEM = readmap(
+        self.DEM = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "GENERAL", "dem", "dem.map"),
             )
         )  # -> This has to be implemented for all readmap functions
-        self.Slope = readmap(
+        self.Slope = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "GENERAL", "Slope", "slope.map"),
             )
         )
-        self.Locations = readmap(
+        self.Locations = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
@@ -410,57 +411,57 @@ class WflowModel(DynamicModel):
         )
 
         # -read soil maps
-        # self.Soil = readmap(self.inpath + config.get('SOIL','Soil'))
-        self.RootFieldMap = readmap(
+        # self.Soil = pcr.readmap(self.inpath + config.get('SOIL','Soil'))
+        self.RootFieldMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "RootFieldMap", "root_field.map"),
             )
         )
-        self.RootSatMap = readmap(
+        self.RootSatMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "RootSatMap", "root_sat.map"),
             )
         )
-        self.RootDryMap = readmap(
+        self.RootDryMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "RootDryMap", "root_dry.map"),
             )
         )
-        self.RootWiltMap = readmap(
+        self.RootWiltMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "RootWiltMap", "root_wilt.map"),
             )
         )
-        self.RootKsat = readmap(
+        self.RootKsat = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "RootKsat", "root_ksat.map"),
             )
         )
-        self.SubSatMap = readmap(
+        self.SubSatMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "SubSatMap", "sub_sat.map"),
             )
         )
-        self.SubFieldMap = readmap(
+        self.SubFieldMap = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
                 configget(self.config, "SOIL", "SubFieldMap", "sub_field.map"),
             )
         )
-        self.SubKsat = readmap(
+        self.SubKsat = pcr.readmap(
             os.path.join(
                 self.Dir,
                 "staticmaps",
@@ -473,11 +474,11 @@ class WflowModel(DynamicModel):
         pars = ["CapRiseMax", "RootDepthFlat", "SubDepthFlat"]
         for i in pars:
             try:
-                # setattr(self, i, readmap(self.inpath + config.get('SOILPARS',i)))
+                # setattr(self, i, pcr.readmap(self.inpath + config.get('SOILPARS',i)))
                 setattr(
                     self,
                     i,
-                    readmap(
+                    pcr.readmap(
                         os.path.join(
                             self.Dir,
                             "staticmaps",
@@ -496,13 +497,13 @@ class WflowModel(DynamicModel):
                 self.Seepmaps = self.inpath + config.get("SOILPARS", "SeePage")
             else:  # -set a static map or value for seepage
                 try:
-                    self.SeePage = readmap(
+                    self.SeePage = pcr.readmap(
                         self.inpath + config.get("SOILPARS", "SeePage")
                     )
                 except:
                     self.SeePage = config.getfloat("SOILPARS", "SeePage")
             try:
-                self.GWL_base = readmap(
+                self.GWL_base = pcr.readmap(
                     self.inpath + config.get("SOILPARS", "GWL_base")
                 )
             except:
@@ -514,7 +515,7 @@ class WflowModel(DynamicModel):
             for i in pars:
                 try:
                     setattr(
-                        self, i, readmap(self.inpath + config.get("GROUNDW_PARS", i))
+                        self, i, pcr.readmap(self.inpath + config.get("GROUNDW_PARS", i))
                     )
                 except:
                     setattr(
@@ -542,7 +543,7 @@ class WflowModel(DynamicModel):
             )
             if self.KcStatFLAG == 1:
                 # -read land use map and kc table
-                self.LandUse = readmap(
+                self.LandUse = pcr.readmap(
                     os.path.join(
                         self.Dir,
                         "staticmaps",
@@ -554,7 +555,7 @@ class WflowModel(DynamicModel):
                     "staticmaps",
                     configget(self.config, "LANDUSE", "CropFac", "kc.tbl"),
                 )
-                self.Kc = lookupscalar(self.kc_table, self.LandUse)
+                self.Kc = pcr.lookupscalar(self.kc_table, self.LandUse)
             else:
                 # -set the kc map series
                 self.Kcmaps = self.inpath + config.get("LANDUSE", "KC")
@@ -575,15 +576,15 @@ class WflowModel(DynamicModel):
             ]
             for i in pars:
                 try:
-                    setattr(self, i, readmap(self.inpath + config.get("DYNVEG", i)))
+                    setattr(self, i, pcr.readmap(self.inpath + config.get("DYNVEG", i)))
                 except:
                     setattr(self, i, config.getfloat("DYNVEG", i))
 
         # -read and set glacier maps and parameters if glacier module is used
         if self.GlacFLAG == 1:
-            # self.GlacFracCI = readmap(self.inpath + config.get('GLACIER','GlacFracCI'))
-            # self.GlacFracDB = readmap(self.inpath + config.get('GLACIER','GlacFracDB'))
-            self.GlacFracCI = readmap(
+            # self.GlacFracCI = pcr.readmap(self.inpath + config.get('GLACIER','GlacFracCI'))
+            # self.GlacFracDB = pcr.readmap(self.inpath + config.get('GLACIER','GlacFracDB'))
+            self.GlacFracCI = pcr.readmap(
                 os.path.join(
                     self.Dir,
                     "staticmaps",
@@ -592,7 +593,7 @@ class WflowModel(DynamicModel):
                     ),
                 )
             )
-            self.GlacFracDB = readmap(
+            self.GlacFracDB = pcr.readmap(
                 os.path.join(
                     self.Dir,
                     "staticmaps",
@@ -604,7 +605,7 @@ class WflowModel(DynamicModel):
             pars = ["DDFG", "DDFDG", "GlacF"]
             for i in pars:
                 try:
-                    setattr(self, i, readmap(self.inpath + config.get("GLACIER", i)))
+                    setattr(self, i, pcr.readmap(self.inpath + config.get("GLACIER", i)))
                 except:
                     # setattr(self, i, config.getfloat('GLACIER',i))
                     setattr(self, i, float(configget(self.config, "GLACIER", i, i)))
@@ -614,7 +615,7 @@ class WflowModel(DynamicModel):
             pars = ["Tcrit", "SnowSC", "DDFS"]
             for i in pars:
                 try:
-                    setattr(self, i, readmap(self.inpath + config.get("SNOW", i)))
+                    setattr(self, i, pcr.readmap(self.inpath + config.get("SNOW", i)))
                 except:
                     #                setattr(self, i, float(configget(self.config,'SNOW',i,i)))
                     setattr(self, i, float(configget(self.config, "SNOW", i, i)))
@@ -644,8 +645,8 @@ class WflowModel(DynamicModel):
         if self.ETREF_FLAG == 1:
             self.ETref = self.inpath + config.get("ETREF", "ETref")
         else:
-            # self.Lat = readmap(self.inpath + config.get('ETREF','Lat'))
-            self.Lat = readmap(
+            # self.Lat = pcr.readmap(self.inpath + config.get('ETREF','Lat'))
+            self.Lat = pcr.readmap(
                 os.path.join(
                     self.Dir,
                     "staticmaps",
@@ -667,8 +668,8 @@ class WflowModel(DynamicModel):
 
         # -read and set routing maps and parameters
         if self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1:
-            # self.FlowDir = readmap(self.inpath + config.get('ROUTING','flowdir'))
-            self.FlowDir = readmap(
+            # self.FlowDir = pcr.readmap(self.inpath + config.get('ROUTING','flowdir'))
+            self.FlowDir = pcr.readmap(
                 os.path.join(
                     self.Dir,
                     "staticmaps",
@@ -676,16 +677,16 @@ class WflowModel(DynamicModel):
                 )
             )
             try:
-                self.kx = readmap(self.inpath + config.get("ROUTING", "kx"))
+                self.kx = pcr.readmap(self.inpath + config.get("ROUTING", "kx"))
             except:
                 # self.kx = config.getfloat('ROUTING','kx')
                 self.kx = float(configget(self.config, "ROUTING", "kx", 1))
 
-        setglobaloption("matrixtable")
+        pcr.setglobaloption("matrixtable")
         # -read lake maps and parameters if lake module is used
         if self.LakeFLAG == 1:
             # nominal map with lake IDs
-            self.LakeID = cover(readmap(self.inpath + config.get("LAKE", "LakeId")), 0)
+            self.LakeID = pcr.cover(pcr.readmap(self.inpath + config.get("LAKE", "LakeId")), 0)
             # lookup table with function for each lake (exp, 1-order poly, 2-order poly, 3-order poly)
             LakeFunc_Tab = self.inpath + config.get("LAKE", "LakeFunc")
             # lookup table with Qh-coeficients for each lake
@@ -699,29 +700,29 @@ class WflowModel(DynamicModel):
             self.LakeSH_Func = lookupnominal(LakeFunc_Tab, 2, self.LakeID)
             self.LakeHS_Func = lookupnominal(LakeFunc_Tab, 3, self.LakeID)
             # Read QH coefficients
-            self.LakeQH_exp_a = lookupscalar(LakeQH_Tab, 1, self.LakeID)
-            self.LakeQH_exp_b = lookupscalar(LakeQH_Tab, 2, self.LakeID)
-            self.LakeQH_pol_b = lookupscalar(LakeQH_Tab, 3, self.LakeID)
-            self.LakeQH_pol_a1 = lookupscalar(LakeQH_Tab, 4, self.LakeID)
-            self.LakeQH_pol_a2 = lookupscalar(LakeQH_Tab, 5, self.LakeID)
-            self.LakeQH_pol_a3 = lookupscalar(LakeQH_Tab, 6, self.LakeID)
+            self.LakeQH_exp_a = pcr.lookupscalar(LakeQH_Tab, 1, self.LakeID)
+            self.LakeQH_exp_b = pcr.lookupscalar(LakeQH_Tab, 2, self.LakeID)
+            self.LakeQH_pol_b = pcr.lookupscalar(LakeQH_Tab, 3, self.LakeID)
+            self.LakeQH_pol_a1 = pcr.lookupscalar(LakeQH_Tab, 4, self.LakeID)
+            self.LakeQH_pol_a2 = pcr.lookupscalar(LakeQH_Tab, 5, self.LakeID)
+            self.LakeQH_pol_a3 = pcr.lookupscalar(LakeQH_Tab, 6, self.LakeID)
             # Read SH coefficients
-            self.LakeSH_exp_a = lookupscalar(LakeSH_Tab, 1, self.LakeID)
-            self.LakeSH_exp_b = lookupscalar(LakeSH_Tab, 2, self.LakeID)
-            self.LakeSH_pol_b = lookupscalar(LakeSH_Tab, 3, self.LakeID)
-            self.LakeSH_pol_a1 = lookupscalar(LakeSH_Tab, 4, self.LakeID)
-            self.LakeSH_pol_a2 = lookupscalar(LakeSH_Tab, 5, self.LakeID)
-            self.LakeSH_pol_a3 = lookupscalar(LakeSH_Tab, 6, self.LakeID)
+            self.LakeSH_exp_a = pcr.lookupscalar(LakeSH_Tab, 1, self.LakeID)
+            self.LakeSH_exp_b = pcr.lookupscalar(LakeSH_Tab, 2, self.LakeID)
+            self.LakeSH_pol_b = pcr.lookupscalar(LakeSH_Tab, 3, self.LakeID)
+            self.LakeSH_pol_a1 = pcr.lookupscalar(LakeSH_Tab, 4, self.LakeID)
+            self.LakeSH_pol_a2 = pcr.lookupscalar(LakeSH_Tab, 5, self.LakeID)
+            self.LakeSH_pol_a3 = pcr.lookupscalar(LakeSH_Tab, 6, self.LakeID)
             # Read HS coefficients
-            self.LakeHS_exp_a = lookupscalar(LakeHS_Tab, 1, self.LakeID)
-            self.LakeHS_exp_b = lookupscalar(LakeHS_Tab, 2, self.LakeID)
-            self.LakeHS_pol_b = lookupscalar(LakeHS_Tab, 3, self.LakeID)
-            self.LakeHS_pol_a1 = lookupscalar(LakeHS_Tab, 4, self.LakeID)
-            self.LakeHS_pol_a2 = lookupscalar(LakeHS_Tab, 5, self.LakeID)
-            self.LakeHS_pol_a3 = lookupscalar(LakeHS_Tab, 6, self.LakeID)
+            self.LakeHS_exp_a = pcr.lookupscalar(LakeHS_Tab, 1, self.LakeID)
+            self.LakeHS_exp_b = pcr.lookupscalar(LakeHS_Tab, 2, self.LakeID)
+            self.LakeHS_pol_b = pcr.lookupscalar(LakeHS_Tab, 3, self.LakeID)
+            self.LakeHS_pol_a1 = pcr.lookupscalar(LakeHS_Tab, 4, self.LakeID)
+            self.LakeHS_pol_a2 = pcr.lookupscalar(LakeHS_Tab, 5, self.LakeID)
+            self.LakeHS_pol_a3 = pcr.lookupscalar(LakeHS_Tab, 6, self.LakeID)
             # -read water level maps and parameters if available
             try:
-                self.UpdateLakeLevel = readmap(
+                self.UpdateLakeLevel = pcr.readmap(
                     self.inpath + config.get("LAKE", "updatelakelevel")
                 )
                 self.LLevel = self.inpath + config.get("LAKE", "LakeFile")
@@ -732,20 +733,20 @@ class WflowModel(DynamicModel):
         # -read reservior maps and parameters if reservoir module is used
         if self.ResFLAG == 1:
             # nominal map with reservoir IDs
-            self.ResID = cover(
-                readmap(self.inpath + config.get("RESERVOIR", "ResId")), 0
+            self.ResID = pcr.cover(
+                pcr.readmap(self.inpath + config.get("RESERVOIR", "ResId")), 0
             )
             # lookup table with operational scheme to use (simple or advanced)
             ResFunc_Tab = self.inpath + config.get("RESERVOIR", "ResFuncStor")
             # Reservoir function
-            self.ResFunc = cover(lookupscalar(ResFunc_Tab, 1, self.ResID), 0)
+            self.ResFunc = pcr.cover(pcr.lookupscalar(ResFunc_Tab, 1, self.ResID), 0)
             try:
                 # lookup table with coefficients for simple reservoirs
                 ResSimple_Tab = self.inpath + config.get("RESERVOIR", "ResSimple")
                 # Read coefficients for simple reservoirs
-                self.ResKr = lookupscalar(ResSimple_Tab, 1, self.ResID)
+                self.ResKr = pcr.lookupscalar(ResSimple_Tab, 1, self.ResID)
                 self.ResSmax = (
-                    lookupscalar(ResSimple_Tab, 2, self.ResID) * 10 ** 6
+                    pcr.lookupscalar(ResSimple_Tab, 2, self.ResID) * 10 ** 6
                 )  # convert to m3
                 self.ResSimple = True
             except:
@@ -755,19 +756,19 @@ class WflowModel(DynamicModel):
                 ResAdvanced_Tab = self.inpath + config.get("RESERVOIR", "ResAdv")
                 # Read coefficients for advanced reservoirs
                 self.ResEVOL = (
-                    lookupscalar(ResAdvanced_Tab, 1, self.ResID) * 10 ** 6
+                    pcr.lookupscalar(ResAdvanced_Tab, 1, self.ResID) * 10 ** 6
                 )  # convert to m3
                 self.ResPVOL = (
-                    lookupscalar(ResAdvanced_Tab, 2, self.ResID) * 10 ** 6
+                    pcr.lookupscalar(ResAdvanced_Tab, 2, self.ResID) * 10 ** 6
                 )  # convert to m3
                 self.ResMaxFl = (
-                    lookupscalar(ResAdvanced_Tab, 3, self.ResID) * 10 ** 6
+                    pcr.lookupscalar(ResAdvanced_Tab, 3, self.ResID) * 10 ** 6
                 )  # convert to m3/d
                 self.ResDemFl = (
-                    lookupscalar(ResAdvanced_Tab, 4, self.ResID) * 10 ** 6
+                    pcr.lookupscalar(ResAdvanced_Tab, 4, self.ResID) * 10 ** 6
                 )  # convert to m3/d
-                self.ResFlStart = lookupscalar(ResAdvanced_Tab, 5, self.ResID)
-                self.ResFlEnd = lookupscalar(ResAdvanced_Tab, 6, self.ResID)
+                self.ResFlStart = pcr.lookupscalar(ResAdvanced_Tab, 5, self.ResID)
+                self.ResFlEnd = pcr.lookupscalar(ResAdvanced_Tab, 6, self.ResID)
                 self.ResAdvanced = True
             except:
                 self.ResAdvanced = False
@@ -793,7 +794,7 @@ class WflowModel(DynamicModel):
         # try:
         # self.RootWater = config.getfloat('SOIL_INIT','RootWater')
         # except:
-        # self.RootWater = readmap(self.inpath + config.get('SOIL_INIT','RootWater'))
+        # self.RootWater = pcr.readmap(self.inpath + config.get('SOIL_INIT','RootWater'))
         # #-initial water content in subsoil
         # if not config.get('SOIL_INIT','SubWater'):
         # self.SubWater = self.SubField
@@ -801,7 +802,7 @@ class WflowModel(DynamicModel):
         # try:
         # self.SubWater = config.getfloat('SOIL_INIT','SubWater')
         # except:
-        # self.SubWater = readmap(self.inpath + config.get('SOIL_INIT','SubWater'))
+        # self.SubWater = pcr.readmap(self.inpath + config.get('SOIL_INIT','SubWater'))
         # -initial water storage in rootzone + subsoil
         self.SoilWater = self.RootWater + self.SubWater
         # -initial capillary rise
@@ -809,22 +810,22 @@ class WflowModel(DynamicModel):
         # try:
         # self.CapRise = config.getfloat('SOIL_INIT','CapRise')
         # except:
-        # self.CapRise = readmap(self.inpath + config.get('SOIL_INIT','CapRise'))
+        # self.CapRise = pcr.readmap(self.inpath + config.get('SOIL_INIT','CapRise'))
         # -initial drainage from rootzone
         self.RootDrain = configget(self.config, "SOIL_INIT", "RootDrain", 3)
         # try:
         # self.RootDrain = config.getfloat('SOIL_INIT','RootDrain')
         # except:
-        # self.RootDrain = readmap(self.inpath + config.get('SOIL_INIT','RootDrain'))
+        # self.RootDrain = pcr.readmap(self.inpath + config.get('SOIL_INIT','RootDrain'))
 
         if self.DynVegFLAG == 1:
             # -initial canopy storage
             self.Scanopy = 0
             # -initial ndvi if first map is not provided
-            self.ndviOld = scalar((self.NDVImax + self.NDVImin) / 2)
+            self.ndviOld = pcr.scalar((self.NDVImax + self.NDVImin) / 2)
         elif self.KcStatFLAG == 0:
             # -set initial kc value to one, if kc map is not available for first timestep
-            self.KcOld = scalar(1)
+            self.KcOld = pcr.scalar(1)
 
         # -initial groundwater properties
         if self.GroundFLAG == 1:
@@ -838,32 +839,32 @@ class WflowModel(DynamicModel):
             # try:
             # self.GwRecharge = config.getfloat('GROUNDW_INIT','GwRecharge')
             # except:
-            # self.GwRecharge = readmap(self.inpath + config.get('GROUNDW_INIT','GwRecharge'))
+            # self.GwRecharge = pcr.readmap(self.inpath + config.get('GROUNDW_INIT','GwRecharge'))
             # #-initial baseflow
             # try:
             # self.BaseR = config.getfloat('GROUNDW_INIT','BaseR')
             # except:
-            # self.BaseR = readmap(self.inpath + config.get('GROUNDW_INIT','BaseR'))
+            # self.BaseR = pcr.readmap(self.inpath + config.get('GROUNDW_INIT','BaseR'))
             # #-initial groundwater storage
             # try:
             # self.Gw = config.getfloat('GROUNDW_INIT','Gw')
             # except:
-            # self.Gw = readmap(self.inpath + config.get('GROUNDW_INIT','Gw'))
+            # self.Gw = pcr.readmap(self.inpath + config.get('GROUNDW_INIT','Gw'))
             # #-initial groundwater level
             # try:
             # self.H_gw = config.getfloat('GROUNDW_INIT','H_gw')
             # except:
-            # self.H_gw = readmap(self.inpath + config.get('GROUNDW_INIT','H_gw'))
-            # self.H_gw = max((self.RootDepthFlat + self.SubDepthFlat + self.GwDepth)/1000 - self.H_gw, 0)
+            # self.H_gw = pcr.readmap(self.inpath + config.get('GROUNDW_INIT','H_gw'))
+            # self.H_gw = pcr.max((self.RootDepthFlat + self.SubDepthFlat + self.GwDepth)/1000 - self.H_gw, 0)
         # else:
         # #-initial drainage from subsoil
         # try:
         # self.SubDrain = config.getfloat('SOIL_INIT','SubDrain')
         # except:
-        # self.SubDrain = readmap(self.inpath + config.get('SOIL_INIT','SubDrain'))
+        # self.SubDrain = pcr.readmap(self.inpath + config.get('SOIL_INIT','SubDrain'))
         # #-initial seepage value if seepage map series is used
         # if self.SeepStatFLAG == 0:
-        # self.SeepOld = scalar(0)
+        # self.SeepOld = pcr.scalar(0)
 
         # -initial snow properties
         if self.SnowFLAG == 1:
@@ -873,7 +874,7 @@ class WflowModel(DynamicModel):
                     configget(self.config, "SNOW_INIT", "SnowIni", 0)
                 )
             except:
-                self.SnowStore = readmap(
+                self.SnowStore = pcr.readmap(
                     self.inpath + config.get("SNOW_INIT", "SnowIni")
                 )
             # -initial water stored in snowpack
@@ -883,7 +884,7 @@ class WflowModel(DynamicModel):
                 )
                 # self.SnowWatStore = config.getfloat('SNOW_INIT','SnowWatStore')
             except:
-                self.SnowWatStore = readmap(
+                self.SnowWatStore = pcr.readmap(
                     self.inpath + config.get("SNOW_INIT", "SnowWatStore")
                 )
             self.TotalSnowStore = self.SnowStore + self.SnowWatStore
@@ -893,8 +894,8 @@ class WflowModel(DynamicModel):
             # try:
             # self.GlacFrac = config.getfloat('GLACIER_INIT','GlacFrac')
             # except:
-            # self.GlacFrac = readmap(self.inpath + config.get('GLACIER_INIT','GlacFrac'))
-            self.GlacFrac = readmap(
+            # self.GlacFrac = pcr.readmap(self.inpath + config.get('GLACIER_INIT','GlacFrac'))
+            self.GlacFrac = pcr.readmap(
                 os.path.join(
                     self.Dir,
                     "staticmaps",
@@ -911,7 +912,7 @@ class WflowModel(DynamicModel):
                 self.QRAold = config.getfloat("ROUT_INIT", "QRA_init")
             except:
                 try:
-                    self.QRAold = readmap(
+                    self.QRAold = pcr.readmap(
                         self.inpath + config.get("ROUT_INIT", "QRA_init")
                     )
                 except:
@@ -928,7 +929,7 @@ class WflowModel(DynamicModel):
             self.BaseRA_FLAG = True
             # for i in pars:
             # try:
-            # setattr(self, i + 'old', readmap(self.inpath + config.get('ROUT_INIT', i + '_init')))
+            # setattr(self, i + 'old', pcr.readmap(self.inpath + config.get('ROUT_INIT', i + '_init')))
             # setattr(self, i + '_FLAG', True)
             # except:
             # try:
@@ -944,23 +945,23 @@ class WflowModel(DynamicModel):
             if self.LakeFLAG == 1:
                 LakeStor_Tab = self.inpath + config.get("LAKE", "LakeStor")
                 self.StorRES = (
-                    cover(lookupscalar(LakeStor_Tab, 1, self.LakeID), 0) * 10 ** 6
+                    pcr.cover(pcr.lookupscalar(LakeStor_Tab, 1, self.LakeID), 0) * 10 ** 6
                 )  # convert to m3
                 # -Qfrac for lake cells should be zero, else 1
-                self.QFRAC = ifthenelse(self.LakeID != 0, scalar(0), 1)
+                self.QFRAC = pcr.ifthenelse(self.LakeID != 0, pcr.scalar(0), 1)
             if self.ResFLAG == 1:
                 ResStor_Tab = self.inpath + config.get("RESERVOIR", "ResFuncStor")
                 ResStor = (
-                    cover(lookupscalar(ResStor_Tab, 2, self.ResID), 0) * 10 ** 6
+                    pcr.cover(pcr.lookupscalar(ResStor_Tab, 2, self.ResID), 0) * 10 ** 6
                 )  # convert to m3
                 try:
                     self.StorRES = self.StorRES + ResStor
                     # -Qfrac for reservoir cells should be zero, else 1
-                    self.QFRAC = ifthenelse(self.ResID != 0, scalar(0), self.QFRAC)
+                    self.QFRAC = pcr.ifthenelse(self.ResID != 0, pcr.scalar(0), self.QFRAC)
                 except:
                     self.StorRES = ResStor
                     # -Qfrac for reservoir cells should be zero, else 1
-                    self.QFRAC = ifthenelse(self.ResID != 0, scalar(0), 1)
+                    self.QFRAC = pcr.ifthenelse(self.ResID != 0, pcr.scalar(0), 1)
 
             # -initial storage in lakes/reservoirs of individual flow components
             pars = ["RainRA", "SnowRA", "GlacRA", "BaseRA"]
@@ -973,11 +974,11 @@ class WflowModel(DynamicModel):
                         self,
                         i + "stor",
                         (
-                            cover(
-                                lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
+                            pcr.cover(
+                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
                             )
-                            + cover(
-                                lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
+                            + pcr.cover(
+                                pcr.lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
                             )
                         )
                         * 10 ** 6,
@@ -991,8 +992,8 @@ class WflowModel(DynamicModel):
                         setattr(
                             self,
                             i + "stor",
-                            cover(
-                                lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
+                            pcr.cover(
+                                pcr.lookupscalar(LakeStor_Tab, column + 2, self.LakeID), 0
                             )
                             * 10 ** 6,
                         )
@@ -1005,8 +1006,8 @@ class WflowModel(DynamicModel):
                             setattr(
                                 self,
                                 i + "stor",
-                                cover(
-                                    lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
+                                pcr.cover(
+                                    pcr.lookupscalar(ResStor_Tab, column + 3, self.ResID), 0
                                 )
                                 * 10 ** 6,
                             )
@@ -1299,7 +1300,7 @@ class WflowModel(DynamicModel):
                 # fname = config.get('REPORTING', i+'_fname')
                 setattr(self, i + "_fname", fname)
                 #                 try:
-                #                     setattr(self, i, readmap(self.inpath + config.get('INITTOT', i)))
+                #                     setattr(self, i, pcr.readmap(self.inpath + config.get('INITTOT', i)))
                 #                 except:
                 #                     try:
                 #                         setattr(self, i, config.getfloat('INITTOT', i))
@@ -1474,22 +1475,22 @@ class WflowModel(DynamicModel):
         # self.gaugesMap=self.wf_readmap(os.path.join(self.Dir , wflow_mgauges),0.0,fail=True) #: Map with locations of rainfall/evap/temp gauge(s). Only needed if the input to the model is not in maps
         # self.OutputId=self.wf_readmap(os.path.join(self.Dir , wflow_subcatch),0.0,fail=True)       # location of subcatchment
 
-        self.ZeroMap = 0.0 * scalar(defined(self.DEM))  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(pcr.defined(self.DEM))  # map with only zero's
 
         # For in memory override:
         # self.Prec, self.Tair, self.Tmax, self.Tmin = self.ZeroMap
 
         # Set static initial values here #########################################
-        self.Latitude = ycoordinate(boolean(self.ZeroMap))
-        self.Longitude = xcoordinate(boolean(self.ZeroMap))
+        self.Latitude = pcr.ycoordinate(pcr.boolean(self.ZeroMap))
+        self.Longitude = pcr.xcoordinate(pcr.boolean(self.ZeroMap))
 
         # self.logger.info("Linking parameters to landuse, catchment and soil...")
 
-        # self.Beta = scalar(0.6) # For sheetflow
-        # #self.M=lookupscalar(self.Dir + "/" + modelEnv['intbl'] + "/M.tbl" ,self.LandUse,subcatch,self.Soil) # Decay parameter in Topog_sbm
-        # self.N=lookupscalar(self.Dir + "/" + self.intbl + "/N.tbl",self.LandUse,subcatch,self.Soil)  # Manning overland flow
+        # self.Beta = pcr.scalar(0.6) # For sheetflow
+        # #self.M=pcr.lookupscalar(self.Dir + "/" + modelEnv['intbl'] + "/M.tbl" ,self.LandUse,subcatch,self.Soil) # Decay parameter in Topog_sbm
+        # self.N=pcr.lookupscalar(self.Dir + "/" + self.intbl + "/N.tbl",self.LandUse,subcatch,self.Soil)  # Manning overland flow
         # """ *Parameter:* Manning's N for all non-river cells """
-        # self.NRiver=lookupscalar(self.Dir + "/" + self.intbl + "/N_River.tbl",self.LandUse,subcatch,self.Soil)  # Manning river
+        # self.NRiver=pcr.lookupscalar(self.Dir + "/" + self.intbl + "/N_River.tbl",self.LandUse,subcatch,self.Soil)  # Manning river
         # """ Manning's N for all cells that are marked as a river """
 
         self.wf_updateparameters()
@@ -1527,25 +1528,25 @@ class WflowModel(DynamicModel):
             self.BaseR = 1
             self.Gw = 1500
             self.H_gw = 3
-            self.SnowIni = cover(0.0)
-            self.SnowWatStore = cover(0.0)
-            self.QRA_init = cover(0.0)
-            self.RainRA_init = cover(0.0)
-            self.BaseRA_init = cover(0.0)
-            self.SnowRA_init = cover(0.0)
-            self.GlacRA_init = cover(0.0)
-            # self.FreeWater =  cover(0.0) #: Water on surface (state variable [mm])
+            self.SnowIni = pcr.cover(0.0)
+            self.SnowWatStore = pcr.cover(0.0)
+            self.QRA_init = pcr.cover(0.0)
+            self.RainRA_init = pcr.cover(0.0)
+            self.BaseRA_init = pcr.cover(0.0)
+            self.SnowRA_init = pcr.cover(0.0)
+            self.GlacRA_init = pcr.cover(0.0)
+            # self.FreeWater =  pcr.cover(0.0) #: Water on surface (state variable [mm])
             # self.SoilMoisture =  self.FC #: Soil moisture (state variable [mm])
             # self.UpperZoneStorage = 0.2 * self.FC #: Storage in Upper Zone (state variable [mm])
             # self.LowerZoneStorage = 1.0/(3.0 * self.K4) #: Storage in Uppe Zone (state variable [mm])
-            # self.InterceptionStorage = cover(0.0) #: Interception Storage (state variable [mm])
-            # self.SurfaceRunoff = cover(0.0) #: Discharge in kinimatic wave (state variable [m^3/s])
-            # self.WaterLevel = cover(0.0) #: Water level in kinimatic wave (state variable [m])
-            # self.DrySnow=cover(0.0) #: Snow amount (state variable [mm])
+            # self.InterceptionStorage = pcr.cover(0.0) #: Interception Storage (state variable [mm])
+            # self.SurfaceRunoff = pcr.cover(0.0) #: Discharge in kinimatic wave (state variable [m^3/s])
+            # self.WaterLevel = pcr.cover(0.0) #: Water level in kinimatic wave (state variable [m])
+            # self.DrySnow=pcr.cover(0.0) #: Snow amount (state variable [mm])
             # if hasattr(self, 'ReserVoirSimpleLocs'):
             #    self.ReservoirVolume = self.ResMaxVolume * self.ResTargetFullFrac
             # if hasattr(self, 'ReserVoirComplexLocs'):
-            #    self.ReservoirWaterLevel = cover(0.0)
+            #    self.ReservoirWaterLevel = pcr.cover(0.0)
         else:
             self.wf_resume(os.path.join(self.Dir, "instate"))
 
@@ -1560,9 +1561,9 @@ class WflowModel(DynamicModel):
         if self.GlacFLAG == 0:
             self.GlacFrac = 0
         if self.SnowFLAG == 0:
-            self.SnowStore = scalar(0)
-        SnowFrac = ifthenelse(self.SnowStore > 0, scalar(1 - self.GlacFrac), 0)
-        RainFrac = ifthenelse(self.SnowStore == 0, scalar(1 - self.GlacFrac), 0)
+            self.SnowStore = pcr.scalar(0)
+        SnowFrac = pcr.ifthenelse(self.SnowStore > 0, pcr.scalar(1 - self.GlacFrac), 0)
+        RainFrac = pcr.ifthenelse(self.SnowStore == 0, pcr.scalar(1 - self.GlacFrac), 0)
 
         # -Read the precipitation time-series
         Precip = self.Prec
@@ -1579,19 +1580,19 @@ class WflowModel(DynamicModel):
                 pcr, self.Hargreaves.extrarad(self, pcr), Temp, TempMax, TempMin
             )
         else:
-            ETref = readmap(generateNameT(self.ETref, self.counter))
+            ETref = pcr.readmap(pcrm.generateNameT(self.ETref, self.counter))
 
         # -Interception and effective precipitation
         # -Update canopy storage
         if self.DynVegFLAG == 1:
             # -try to read the ndvi map series. If not available, then use ndvi old
             try:
-                ndvi = readmap(pcrm.generateNameT(self.ndvi, self.counter))
+                ndvi = pcr.readmap(pcrm.generateNameT(self.ndvi, self.counter))
                 self.ndviOld = ndvi
             except:
                 ndvi = self.ndviOld
             # -fill missing ndvi values with ndvi base
-            ndvi = ifthenelse(defined(ndvi) == 1, ndvi, self.NDVIbase)
+            ndvi = pcr.ifthenelse(pcr.defined(ndvi) == 1, ndvi, self.NDVIbase)
             # -calculate the vegetation parameters
             vegoutput = self.dynamic_veg.Veg_function(
                 pcr,
@@ -1627,7 +1628,7 @@ class WflowModel(DynamicModel):
         elif self.KcStatFLAG == 0:
             # -Try to read the KC map series
             try:
-                self.Kc = readmap(pcrm.generateNameT(self.Kcmaps, self.counter))
+                self.Kc = pcr.readmap(pcrm.generateNameT(self.Kcmaps, self.counter))
                 self.KcOld = self.Kc
             except:
                 self.Kc = self.KcOld
@@ -1636,15 +1637,15 @@ class WflowModel(DynamicModel):
             self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
         ):
             self.PrecSubBasinTSS.sample(
-                catchmenttotal(Precip * (1 - self.GlacFrac), self.FlowDir)
-                / catchmenttotal(1, self.FlowDir)
+                pcr.catchmenttotal(Precip * (1 - self.GlacFrac), self.FlowDir)
+                / pcr.catchmenttotal(1, self.FlowDir)
             )
 
         # Snow and rain
         if self.SnowFLAG == 1:
             # -Snow and rain differentiation
-            Snow = ifthenelse(Temp >= self.Tcrit, 0, Precip)
-            Rain = ifthenelse(Temp < self.Tcrit, 0, Precip)
+            Snow = pcr.ifthenelse(Temp >= self.Tcrit, 0, Precip)
+            Rain = pcr.ifthenelse(Temp < self.Tcrit, 0, Precip)
             # -Report Snow
             self.reporting.reporting(self, pcr, "TotSnow", Snow)
             self.reporting.reporting(self, pcr, "TotSnowF", Snow * (1 - self.GlacFrac))
@@ -1709,8 +1710,8 @@ class WflowModel(DynamicModel):
                 self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
             ):
                 self.GMeltSubBasinTSS.sample(
-                    catchmenttotal(GlacMelt * self.GlacFrac, self.FlowDir)
-                    / catchmenttotal(1, self.FlowDir)
+                    pcr.catchmenttotal(GlacMelt * self.GlacFrac, self.FlowDir)
+                    / pcr.catchmenttotal(1, self.FlowDir)
                 )
             # -Glacier runoff
             GlacR = self.glacier.GlacR(self.GlacF, GlacMelt, self.GlacFrac)
@@ -1733,7 +1734,7 @@ class WflowModel(DynamicModel):
 
         # -Rootzone calculations
         self.RootWater = (
-            self.RootWater + ifthenelse(RainFrac > 0, Rain, 0) + self.CapRise
+            self.RootWater + pcr.ifthenelse(RainFrac > 0, Rain, 0) + self.CapRise
         )
         # -Rootzone runoff
         RootRunoff = self.rootzone.RootRunoff(
@@ -1741,8 +1742,8 @@ class WflowModel(DynamicModel):
         )
         self.RootWater = self.RootWater - RootRunoff
         # -Actual evapotranspiration
-        etreddry = max(
-            min((self.RootWater - self.RootDry) / (self.RootWilt - self.RootDry), 1), 0
+        etreddry = pcr.max(
+            pcr.min((self.RootWater - self.RootDry) / (self.RootWilt - self.RootDry), 1), 0
         )
         ETact = self.ET.ETact(
             pcr, ETpot, self.RootWater, self.RootSat, etreddry, RainFrac
@@ -1757,10 +1758,10 @@ class WflowModel(DynamicModel):
             self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
         ):
             self.ETaSubBasinTSS.sample(
-                catchmenttotal(ActETact, self.FlowDir) / catchmenttotal(1, self.FlowDir)
+                pcr.catchmenttotal(ActETact, self.FlowDir) / pcr.catchmenttotal(1, self.FlowDir)
             )
         # -Update rootwater content
-        self.RootWater = max(self.RootWater - ETact, 0)
+        self.RootWater = pcr.max(self.RootWater - ETact, 0)
         # -Rootwater drainage
         self.RootDrain = self.rootzone.RootDrainage(
             pcr,
@@ -1787,21 +1788,21 @@ class WflowModel(DynamicModel):
         if self.GroundFLAG == 0:
             if self.SeepStatFLAG == 0:
                 try:
-                    self.SeePage = readmap(
+                    self.SeePage = pcr.readmap(
                         pcrm.generateNameT(self.Seepmaps, self.counter)
                     )
                     self.SeepOld = self.SeePage
                 except:
                     self.SeePage = self.SeepOld
             # -Report seepage
-            self.reporting.reporting(self, pcr, "TotSeepF", scalar(self.SeePage))
-            self.SubWater = min(max(self.SubWater - self.SeePage, 0), self.SubSat)
+            self.reporting.reporting(self, pcr, "TotSeepF", pcr.scalar(self.SeePage))
+            self.SubWater = pcr.min(pcr.max(self.SubWater - self.SeePage, 0), self.SubSat)
             if self.mm_rep_FLAG == 1 and (
                 self.RoutFLAG == 1 or self.ResFLAG == 1 or self.LakeFLAG == 1
             ):
                 self.SeepSubBasinTSS.sample(
-                    catchmenttotal(self.SeePage, self.FlowDir)
-                    / catchmenttotal(1, self.FlowDir)
+                    pcr.catchmenttotal(self.SeePage, self.FlowDir)
+                    / pcr.catchmenttotal(1, self.FlowDir)
                 )
         # -Capillary rise
         self.CapRise = self.subzone.CapilRise(
@@ -1942,9 +1943,9 @@ class WflowModel(DynamicModel):
         # -Routing for lake and/or reservoir modules
         if self.LakeFLAG == 1 or self.ResFLAG == 1:
             # -Update storage in lakes/reservoirs (m3) with specific runoff
-            self.StorRES = self.StorRES + ifthenelse(
+            self.StorRES = self.StorRES + pcr.ifthenelse(
                 self.QFRAC == 0,
-                0.001 * cellarea() * (self.BaseR + RainR + GlacR + SnowR),
+                0.001 * pcr.cellarea() * (self.BaseR + RainR + GlacR + SnowR),
                 0,
             )
             OldStorage = self.StorRES
@@ -1955,8 +1956,8 @@ class WflowModel(DynamicModel):
                 self.StorRES = tempvar[1]
                 LakeQ = self.lakes.QLake(self, pcr, LakeLevel)
                 ResQ = self.reservoirs.QRes(self, pcr)
-                Qout = ifthenelse(
-                    self.ResID != 0, ResQ, ifthenelse(self.LakeID != 0, LakeQ, 0)
+                Qout = pcr.ifthenelse(
+                    self.ResID != 0, ResQ, pcr.ifthenelse(self.LakeID != 0, LakeQ, 0)
                 )
             elif self.LakeFLAG == 1:
                 tempvar = self.lakes.UpdateLakeHStore(self, pcr, pcrm)
@@ -1967,10 +1968,10 @@ class WflowModel(DynamicModel):
                 Qout = self.reservoirs.QRes(self, pcr)
 
             # -Calculate volume available for routing (=outflow lakes/reservoir + cell specific runoff)
-            RunoffVolume = upstream(self.FlowDir, Qout) + ifthenelse(
+            RunoffVolume = pcr.upstream(self.FlowDir, Qout) + pcr.ifthenelse(
                 self.QFRAC == 0,
                 0,
-                0.001 * cellarea() * (self.BaseR + RainR + GlacR + SnowR),
+                0.001 * pcr.cellarea() * (self.BaseR + RainR + GlacR + SnowR),
             )
             # -Routing of total flow
             tempvar = self.routing.ROUT(
@@ -1984,7 +1985,7 @@ class WflowModel(DynamicModel):
             # -report flux in mm
             if self.mm_rep_FLAG == 1:
                 self.QTOTSubBasinTSS.sample(
-                    ((Q * 3600 * 24) / catchmenttotal(cellarea(), self.FlowDir)) * 1000
+                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)) * 1000
                 )
             # -report lake and reservoir waterbalance
             if self.LakeFLAG == 1 and config.getint("REPORTING", "Lake_wbal") == 1:
@@ -1999,13 +2000,13 @@ class WflowModel(DynamicModel):
             # -Routing of individual contributers
             # -Snow routing
             if self.SnowRA_FLAG == 1 and self.SnowFLAG == 1:
-                self.SnowRAstor = self.SnowRAstor + ifthenelse(
-                    self.QFRAC == 0, SnowR * 0.001 * cellarea(), 0
+                self.SnowRAstor = self.SnowRAstor + pcr.ifthenelse(
+                    self.QFRAC == 0, SnowR * 0.001 * pcr.cellarea(), 0
                 )
-                cQfrac = cover(self.SnowRAstor / OldStorage, 0)
+                cQfrac = pcr.cover(self.SnowRAstor / OldStorage, 0)
                 cQout = cQfrac * Qout
-                cRunoffVolume = upstream(self.FlowDir, cQout) + ifthenelse(
-                    self.QFRAC == 0, 0, 0.001 * cellarea() * SnowR
+                cRunoffVolume = pcr.upstream(self.FlowDir, cQout) + pcr.ifthenelse(
+                    self.QFRAC == 0, 0, 0.001 * pcr.cellarea() * SnowR
                 )
                 tempvar = self.routing.ROUT(
                     self, pcr, cRunoffVolume, self.SnowRAold, cQout, self.SnowRAstor
@@ -2019,7 +2020,7 @@ class WflowModel(DynamicModel):
                     self.QSNOWSubBasinTSS.sample(
                         (
                             (SnowRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2034,13 +2035,13 @@ class WflowModel(DynamicModel):
                     self.ResSnowStorTSS.sample(self.SnowRAstor)
             # -Rain routing
             if self.RainRA_FLAG == 1:
-                self.RainRAstor = self.RainRAstor + ifthenelse(
-                    self.QFRAC == 0, RainR * 0.001 * cellarea(), 0
+                self.RainRAstor = self.RainRAstor + pcr.ifthenelse(
+                    self.QFRAC == 0, RainR * 0.001 * pcr.cellarea(), 0
                 )
-                cQfrac = cover(self.RainRAstor / OldStorage, 0)
+                cQfrac = pcr.cover(self.RainRAstor / OldStorage, 0)
                 cQout = cQfrac * Qout
-                cRunoffVolume = upstream(self.FlowDir, cQout) + ifthenelse(
-                    self.QFRAC == 0, 0, 0.001 * cellarea() * RainR
+                cRunoffVolume = pcr.upstream(self.FlowDir, cQout) + pcr.ifthenelse(
+                    self.QFRAC == 0, 0, 0.001 * pcr.cellarea() * RainR
                 )
                 tempvar = self.routing.ROUT(
                     self, pcr, cRunoffVolume, self.RainRAold, cQout, self.RainRAstor
@@ -2054,7 +2055,7 @@ class WflowModel(DynamicModel):
                     self.QRAINSubBasinTSS.sample(
                         (
                             (RainRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2069,13 +2070,13 @@ class WflowModel(DynamicModel):
                     self.ResRainStorTSS.sample(self.RainRAstor)
             # -Glacier routing
             if self.GlacRA_FLAG == 1 and self.GlacFLAG == 1:
-                self.GlacRAstor = self.GlacRAstor + ifthenelse(
-                    self.QFRAC == 0, GlacR * 0.001 * cellarea(), 0
+                self.GlacRAstor = self.GlacRAstor + pcr.ifthenelse(
+                    self.QFRAC == 0, GlacR * 0.001 * pcr.cellarea(), 0
                 )
-                cQfrac = cover(self.GlacRAstor / OldStorage, 0)
+                cQfrac = pcr.cover(self.GlacRAstor / OldStorage, 0)
                 cQout = cQfrac * Qout
-                cRunoffVolume = upstream(self.FlowDir, cQout) + ifthenelse(
-                    self.QFRAC == 0, 0, 0.001 * cellarea() * GlacR
+                cRunoffVolume = pcr.upstream(self.FlowDir, cQout) + pcr.ifthenelse(
+                    self.QFRAC == 0, 0, 0.001 * pcr.cellarea() * GlacR
                 )
                 tempvar = self.routing.ROUT(
                     self, pcr, cRunoffVolume, self.GlacRAold, cQout, self.GlacRAstor
@@ -2089,7 +2090,7 @@ class WflowModel(DynamicModel):
                     self.QGLACSubBasinTSS.sample(
                         (
                             (GlacRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2104,13 +2105,13 @@ class WflowModel(DynamicModel):
                     self.ResGlacStorTSS.sample(self.GlacRAstor)
             # -Baseflow routing
             if self.BaseRA_FLAG == 1:
-                self.BaseRAstor = self.BaseRAstor + ifthenelse(
-                    self.QFRAC == 0, self.BaseR * 0.001 * cellarea(), 0
+                self.BaseRAstor = self.BaseRAstor + pcr.ifthenelse(
+                    self.QFRAC == 0, self.BaseR * 0.001 * pcr.cellarea(), 0
                 )
-                cQfrac = cover(self.BaseRAstor / OldStorage, 0)
+                cQfrac = pcr.cover(self.BaseRAstor / OldStorage, 0)
                 cQout = cQfrac * Qout
-                cRunoffVolume = upstream(self.FlowDir, cQout) + ifthenelse(
-                    self.QFRAC == 0, 0, 0.001 * cellarea() * self.BaseR
+                cRunoffVolume = pcr.upstream(self.FlowDir, cQout) + pcr.ifthenelse(
+                    self.QFRAC == 0, 0, 0.001 * pcr.cellarea() * self.BaseR
                 )
                 tempvar = self.routing.ROUT(
                     self, pcr, cRunoffVolume, self.BaseRAold, cQout, self.BaseRAstor
@@ -2124,7 +2125,7 @@ class WflowModel(DynamicModel):
                     self.QBASFSubBasinTSS.sample(
                         (
                             (BaseRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2152,7 +2153,7 @@ class WflowModel(DynamicModel):
             self.reporting.reporting(self, pcr, "QallRAtot", Q)
             if self.mm_rep_FLAG == 1:
                 self.QTOTSubBasinTSS.sample(
-                    ((Q * 3600 * 24) / catchmenttotal(cellarea(), self.FlowDir)) * 1000
+                    ((Q * 3600 * 24) / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)) * 1000
                 )
             # -Snow routing
             if self.SnowRA_FLAG == 1 and self.SnowFLAG == 1:
@@ -2165,7 +2166,7 @@ class WflowModel(DynamicModel):
                     self.QSNOWSubBasinTSS.sample(
                         (
                             (SnowRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2180,7 +2181,7 @@ class WflowModel(DynamicModel):
                     self.QRAINSubBasinTSS.sample(
                         (
                             (RainRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2195,7 +2196,7 @@ class WflowModel(DynamicModel):
                     self.QGLACSubBasinTSS.sample(
                         (
                             (GlacRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )
@@ -2210,7 +2211,7 @@ class WflowModel(DynamicModel):
                     self.QBASFSubBasinTSS.sample(
                         (
                             (BaseRA * 3600 * 24)
-                            / catchmenttotal(cellarea(), self.FlowDir)
+                            / pcr.catchmenttotal(pcr.cellarea(), self.FlowDir)
                         )
                         * 1000
                     )

--- a/wflow/wflow_topoflex.py
+++ b/wflow/wflow_topoflex.py
@@ -19,6 +19,7 @@ wflow_topoflex  -C case -R Runid -c inifile
 import os.path
 from copy import deepcopy as copylist
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -40,7 +41,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. This is your work!
   """
@@ -53,8 +54,8 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
       
       """
-        DynamicModel.__init__(self)
-        setclone(os.path.join(Dir, "staticmaps", cloneMap))
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(os.path.join(Dir, "staticmaps", cloneMap))
         self.runId = RunDir
         self.caseName = os.path.abspath(Dir)
         self.Dir = os.path.abspath(Dir)
@@ -170,10 +171,10 @@ class WflowModel(DynamicModel):
         )
         if os.path.exists(mapname):
             self.logger.info("reading map parameter file: " + mapname)
-            rest = cover(readmap(mapname), default)
+            rest = pcr.cover(pcr.readmap(mapname), default)
         else:
             if os.path.isfile(pathtotbl):
-                rest = cover(lookupscalar(pathtotbl, landuse, subcatch, soil), default)
+                rest = pcr.cover(pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default)
                 self.logger.info("Creating map from table: " + pathtotbl)
             else:
                 self.logger.warning(
@@ -182,7 +183,7 @@ class WflowModel(DynamicModel):
                     + ") returning default value: "
                     + str(default)
                 )
-                rest = scalar(default)
+                rest = pcr.scalar(default)
 
         return rest
 
@@ -204,7 +205,7 @@ class WflowModel(DynamicModel):
             self.logger.info("Saving initial conditions for FEWS...")
             #            self.wf_suspend(os.path.join(self.Dir, "outstate"))
             [
-                report(
+                pcr.report(
                     self.Si[i],
                     self.Dir + "/outstate/Si" + self.NamesClasses[i] + ".map",
                 )
@@ -212,7 +213,7 @@ class WflowModel(DynamicModel):
                 if self.selectSi[i]
             ]
             [
-                report(
+                pcr.report(
                     self.Su[i],
                     self.Dir + "/outstate/Su" + self.NamesClasses[i] + ".map",
                 )
@@ -220,7 +221,7 @@ class WflowModel(DynamicModel):
                 if self.selectSu[i]
             ]
             [
-                report(
+                pcr.report(
                     self.Sa[i],
                     self.Dir + "/outstate/Sa" + self.NamesClasses[i] + ".map",
                 )
@@ -228,7 +229,7 @@ class WflowModel(DynamicModel):
                 if self.selectSa[i]
             ]
             [
-                report(
+                pcr.report(
                     self.Sf[i],
                     self.Dir + "/outstate/Sf" + self.NamesClasses[i] + ".map",
                 )
@@ -236,7 +237,7 @@ class WflowModel(DynamicModel):
                 if self.selectSf[i]
             ]
             [
-                report(
+                pcr.report(
                     self.Sfa[i],
                     self.Dir + "/outstate/Sfa" + self.NamesClasses[i] + ".map",
                 )
@@ -244,22 +245,22 @@ class WflowModel(DynamicModel):
                 if self.selectSfa[i]
             ]
             [
-                report(
+                pcr.report(
                     self.Sw[i],
                     self.Dir + "/outstate/Sw" + self.NamesClasses[i] + ".map",
                 )
                 for i in self.Classes
                 if self.selectSw[i]
             ]
-            report(self.Ss, self.Dir + "/outstate/Ss.map")
-            report(self.Qstate, self.Dir + "/outstate/Qstate.map")
-            report(self.WaterLevel, self.Dir + "/outstate/WaterLevel.map")
+            pcr.report(self.Ss, self.Dir + "/outstate/Ss.map")
+            pcr.report(self.Qstate, self.Dir + "/outstate/Qstate.map")
+            pcr.report(self.WaterLevel, self.Dir + "/outstate/WaterLevel.map")
 
         #: It is advised to use the wf_suspend() function
         #: here which will suspend the variables that are given by stateVariables
         #: function.
         [
-            report(
+            pcr.report(
                 self.Si[i],
                 self.SaveDir + "/outstate/Si" + self.NamesClasses[i] + ".map",
             )
@@ -267,7 +268,7 @@ class WflowModel(DynamicModel):
             if self.selectSi[i]
         ]
         [
-            report(
+            pcr.report(
                 self.Su[i],
                 self.SaveDir + "/outstate/Su" + self.NamesClasses[i] + ".map",
             )
@@ -275,7 +276,7 @@ class WflowModel(DynamicModel):
             if self.selectSu[i]
         ]
         [
-            report(
+            pcr.report(
                 self.Sa[i],
                 self.SaveDir + "/outstate/Sa" + self.NamesClasses[i] + ".map",
             )
@@ -283,7 +284,7 @@ class WflowModel(DynamicModel):
             if self.selectSa[i]
         ]
         [
-            report(
+            pcr.report(
                 self.Sf[i],
                 self.SaveDir + "/outstate/Sf" + self.NamesClasses[i] + ".map",
             )
@@ -291,7 +292,7 @@ class WflowModel(DynamicModel):
             if self.selectSf[i]
         ]
         [
-            report(
+            pcr.report(
                 self.Sfa[i],
                 self.SaveDir + "/outstate/Sfa" + self.NamesClasses[i] + ".map",
             )
@@ -299,33 +300,33 @@ class WflowModel(DynamicModel):
             if self.selectSfa[i]
         ]
         [
-            report(
+            pcr.report(
                 self.Sw[i],
                 self.SaveDir + "/outstate/Sw" + self.NamesClasses[i] + ".map",
             )
             for i in self.Classes
             if self.selectSw[i]
         ]
-        report(self.Ss, self.SaveDir + "/outstate/Ss.map")
-        report(self.Qstate, self.SaveDir + "/outstate/Qstate.map")
-        report(self.WaterLevel, self.SaveDir + "/outstate/WaterLevel.map")
+        pcr.report(self.Ss, self.SaveDir + "/outstate/Ss.map")
+        pcr.report(self.Qstate, self.SaveDir + "/outstate/Qstate.map")
+        pcr.report(self.WaterLevel, self.SaveDir + "/outstate/WaterLevel.map")
 
         [
-            report(
+            pcr.report(
                 self.percent[i],
                 self.SaveDir + "/outmaps/percent" + self.NamesClasses[i] + ".map",
             )
             for i in self.Classes
         ]
-        report(self.percentArea, self.SaveDir + "/outmaps/percentArea.map")
-        report(self.surfaceArea, self.SaveDir + "/outmaps/surfaceArea.map")
+        pcr.report(self.percentArea, self.SaveDir + "/outmaps/percentArea.map")
+        pcr.report(self.surfaceArea, self.SaveDir + "/outmaps/surfaceArea.map")
 
-        report(self.sumprecip, self.SaveDir + "/outsum/sumprecip.map")
-        report(self.sumevap, self.SaveDir + "/outsum/sumevap.map")
-        report(self.sumpotevap, self.SaveDir + "/outsum/sumpotevap.map")
-        report(self.sumtemp, self.SaveDir + "/outsum/sumtemp.map")
-        report(self.sumrunoff, self.SaveDir + "/outsum/sumrunoff.map")
-        report(self.sumwb, self.SaveDir + "/outsum/sumwb.map")
+        pcr.report(self.sumprecip, self.SaveDir + "/outsum/sumprecip.map")
+        pcr.report(self.sumevap, self.SaveDir + "/outsum/sumevap.map")
+        pcr.report(self.sumpotevap, self.SaveDir + "/outsum/sumpotevap.map")
+        pcr.report(self.sumtemp, self.SaveDir + "/outsum/sumtemp.map")
+        pcr.report(self.sumrunoff, self.SaveDir + "/outsum/sumrunoff.map")
+        pcr.report(self.sumwb, self.SaveDir + "/outsum/sumwb.map")
 
     def initial(self):
 
@@ -342,9 +343,9 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
+        pcr.setglobaloption("unittrue")
 
-        self.thestep = scalar(0)
+        self.thestep = pcr.scalar(0)
         #: files to be used in case of timesries (scalar) input to the model
         # files for forcing data
         self.precipTss = os.path.join(
@@ -579,49 +580,49 @@ class WflowModel(DynamicModel):
         ]
 
         # 2: Input base maps ########################################################
-        subcatch = ordinal(
-            readmap(os.path.join(self.Dir, wflow_subcatch))
+        subcatch = pcr.ordinal(
+            pcr.readmap(os.path.join(self.Dir, wflow_subcatch))
         )  # Determines the area of calculations (all cells > 0)
-        subcatch = ifthen(subcatch > 0, subcatch)
+        subcatch = pcr.ifthen(subcatch > 0, subcatch)
 
-        self.Altitude = readmap(os.path.join(self.Dir, wflow_dem)) * scalar(
-            defined(subcatch)
+        self.Altitude = pcr.readmap(os.path.join(self.Dir, wflow_dem)) * pcr.scalar(
+            pcr.defined(subcatch)
         )  #: The digital elevation map (DEM)
         self.maxSlope = self.wf_readmap(os.path.join(self.Dir, wflow_maxSlope), 0.0)
-        self.TopoLdd = readmap(
+        self.TopoLdd = pcr.readmap(
             os.path.join(self.Dir, wflow_ldd)
         )  #: The local drinage definition map (ldd)
-        self.TopoId = readmap(
+        self.TopoId = pcr.readmap(
             os.path.join(self.Dir, wflow_subcatch)
         )  #: Map define the area over which the calculations are done (mask)
-        self.catchArea = scalar(ifthen(self.TopoId > 0, scalar(1)))
-        self.LandUse = ordinal(
+        self.catchArea = pcr.scalar(pcr.ifthen(self.TopoId > 0, pcr.scalar(1)))
+        self.LandUse = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_landuse), 0.0, fail=True)
         )  #: Map with lan-use/cover classes
-        self.LandUse = cover(self.LandUse, ordinal(ordinal(subcatch) > 0))
-        self.Soil = ordinal(
+        self.LandUse = pcr.cover(self.LandUse, pcr.ordinal(ordinal(subcatch) > 0))
+        self.Soil = pcr.ordinal(
             self.wf_readmap(os.path.join(self.Dir, wflow_soil), 0.0, fail=True)
         )  #: Map with soil classes
-        self.Soil = cover(self.Soil, ordinal(ordinal(subcatch) > 0))
-        self.TopoId = ifthen(scalar(self.TopoId) > 0, self.TopoId)
-        self.surfaceArea = scalar(
-            readmap(os.path.join(self.Dir, wflow_surfaceArea))
+        self.Soil = pcr.cover(self.Soil, pcr.ordinal(ordinal(subcatch) > 0))
+        self.TopoId = pcr.ifthen(pcr.scalar(self.TopoId) > 0, self.TopoId)
+        self.surfaceArea = pcr.scalar(
+            pcr.readmap(os.path.join(self.Dir, wflow_surfaceArea))
         )  #: Map with surface area per cell
-        self.totalArea = areatotal(self.surfaceArea, nominal(self.TopoId))
+        self.totalArea = pcr.areatotal(self.surfaceArea, pcr.nominal(self.TopoId))
         self.percentArea = self.surfaceArea / self.totalArea
-        self.Transit = scalar(
-            readmap(os.path.join(self.Dir, wflow_transit))
+        self.Transit = pcr.scalar(
+            pcr.readmap(os.path.join(self.Dir, wflow_transit))
         )  #: Map with surface area per cell
-        self.velocity = scalar(
-            readmap(os.path.join(self.Dir, wflow_velocity))
+        self.velocity = pcr.scalar(
+            pcr.readmap(os.path.join(self.Dir, wflow_velocity))
         )  #: Map with surface area per cell
-        self.gaugesR = nominal(readmap(os.path.join(self.Dir, wflow_gauges)))
+        self.gaugesR = pcr.nominal(pcr.readmap(os.path.join(self.Dir, wflow_gauges)))
         self.RiverLength = self.wf_readmap(
             os.path.join(self.Dir, wflow_riverlength), 0.0
         )
         # Factor to multiply riverlength with (defaults to 1.0)
-        self.River = cover(
-            boolean(
+        self.River = pcr.cover(
+            pcr.boolean(
                 self.wf_readmap(os.path.join(self.Dir, wflow_river), 0.0, fail=True)
             ),
             0,
@@ -632,7 +633,7 @@ class WflowModel(DynamicModel):
         self.RiverWidth = self.wf_readmap(os.path.join(self.Dir, wflow_riverwidth), 0.0)
         self.percent = []
         for i in self.Classes:
-            self.percent.append(readmap(os.path.join(self.Dir, wflow_percent[i])))
+            self.percent.append(pcr.readmap(os.path.join(self.Dir, wflow_percent[i])))
 
         self.wf_updateparameters()
         # MODEL PARAMETERS - VALUES PER CLASS
@@ -878,13 +879,13 @@ class WflowModel(DynamicModel):
         )
 
         # kinematic wave parameters
-        self.Beta = scalar(0.6)  # For sheetflow
-        # self.M=lookupscalar(self.Dir + "/" + modelEnv['intbl'] + "/M.tbl" ,self.LandUse,subcatch,self.Soil) # Decay parameter in Topog_sbm
-        self.N = lookupscalar(
+        self.Beta = pcr.scalar(0.6)  # For sheetflow
+        # self.M=pcr.lookupscalar(self.Dir + "/" + modelEnv['intbl'] + "/M.tbl" ,self.LandUse,subcatch,self.Soil) # Decay parameter in Topog_sbm
+        self.N = pcr.lookupscalar(
             self.Dir + "/" + self.intbl + "/N.tbl", self.LandUse, subcatch, self.Soil
         )  # Manning overland flow
         """ *Parameter:* Manning's N for all non-river cells """
-        self.NRiver = lookupscalar(
+        self.NRiver = pcr.lookupscalar(
             self.Dir + "/" + self.intbl + "/N_River.tbl",
             self.LandUse,
             subcatch,
@@ -897,47 +898,47 @@ class WflowModel(DynamicModel):
         self.lamdaS = eval(str(configget(self.config, "model", "lamdaS", "[0]")))
 
         # initialise list for routing
-        self.trackQ = [0 * scalar(self.catchArea)] * int(
+        self.trackQ = [0 * pcr.scalar(self.catchArea)] * int(
             self.maxTransit
         )  # list * scalar ---> list wordt zoveel x gekopieerd als scalar.
 
         # initialise list for lag function
-        self.convQu = [[0 * scalar(self.catchArea)] * self.Tf[i] for i in self.Classes]
-        self.convQa = [[0 * scalar(self.catchArea)] * self.Tfa[i] for i in self.Classes]
+        self.convQu = [[0 * pcr.scalar(self.catchArea)] * self.Tf[i] for i in self.Classes]
+        self.convQa = [[0 * pcr.scalar(self.catchArea)] * self.Tfa[i] for i in self.Classes]
 
         if self.scalarInput:
-            self.gaugesMap = nominal(
-                readmap(os.path.join(self.Dir, wflow_mgauges))
+            self.gaugesMap = pcr.nominal(
+                pcr.readmap(os.path.join(self.Dir, wflow_mgauges))
             )  #: Map with locations of rainfall/evap/temp gauge(s). Only needed if the input to the model is not in maps
-        self.OutputId = readmap(
+        self.OutputId = pcr.readmap(
             os.path.join(self.Dir, wflow_subcatch)
         )  # location of subcatchment
-        self.OutputIdRunoff = boolean(
-            ifthenelse(
-                self.gaugesR == 1, 1 * scalar(self.TopoId), 0 * scalar(self.TopoId)
+        self.OutputIdRunoff = pcr.boolean(
+            pcr.ifthenelse(
+                self.gaugesR == 1, 1 * pcr.scalar(self.TopoId), 0 * pcr.scalar(self.TopoId)
             )
         )  # location of subcatchment
 
-        self.ZeroMap = 0.0 * scalar(subcatch)  # map with only zero's
+        self.ZeroMap = 0.0 * pcr.scalar(subcatch)  # map with only zero's
 
         self.xl, self.yl, self.reallength = pcrut.detRealCellLength(
             self.ZeroMap, sizeinmetres
         )
-        self.Slope = slope(self.Altitude)
-        self.Slope = ifthen(
-            boolean(self.TopoId),
-            max(0.001, self.Slope * celllength() / self.reallength),
+        self.Slope = pcr.slope(self.Altitude)
+        self.Slope = pcr.ifthen(
+            pcr.boolean(self.TopoId),
+            pcr.max(0.001, self.Slope * pcr.celllength() / self.reallength),
         )
-        self.Slope = ifthenelse(self.maxSlope > 0.0, self.maxSlope, self.Slope)
-        Terrain_angle = scalar(atan(self.Slope))
+        self.Slope = pcr.ifthenelse(self.maxSlope > 0.0, self.maxSlope, self.Slope)
+        Terrain_angle = pcr.scalar(pcr.atan(self.Slope))
         temp = (
-            catchmenttotal(cover(1.0), self.TopoLdd)
+            pcr.catchmenttotal(pcr.cover(1.0), self.TopoLdd)
             * self.reallength
             * 0.001
             * 0.001
             * self.reallength
         )
-        self.QMMConvUp = cover(self.timestepsecs * 0.001) / temp
+        self.QMMConvUp = pcr.cover(self.timestepsecs * 0.001) / temp
 
         self.wf_multparameters()
 
@@ -947,16 +948,16 @@ class WflowModel(DynamicModel):
         # "Noah J. Finnegan et al 2005 Controls on the channel width of rivers:
         # Implications for modeling fluvial incision of bedrock"
 
-        upstr = catchmenttotal(1, self.TopoLdd)
-        Qscale = upstr / mapmaximum(upstr) * Qmax
+        upstr = pcr.catchmenttotal(1, self.TopoLdd)
+        Qscale = upstr / pcr.mapmaximum(upstr) * Qmax
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (max(0.0001, windowaverage(self.Slope, celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
-        self.RiverWidth = ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
+        self.RiverWidth = pcr.ifthenelse(self.RiverWidth <= 0.0, W, self.RiverWidth)
 
         # For in memory override:
         self.P = self.ZeroMap
@@ -968,21 +969,21 @@ class WflowModel(DynamicModel):
         # Initializing of variables
 
         self.logger.info("Initializing of model variables..")
-        self.TopoLdd = lddmask(self.TopoLdd, boolean(self.TopoId))
-        catchmentcells = maptotal(scalar(self.TopoId))
+        self.TopoLdd = pcr.lddmask(self.TopoLdd, pcr.boolean(self.TopoId))
+        catchmentcells = pcr.maptotal(pcr.scalar(self.TopoId))
 
         # Limit lateral flow per subcatchment (make pits at all subcatch boundaries)
         # This is very handy for Ribasim etc...
         if self.SubCatchFlowOnly > 0:
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
-            ds = downstream(self.TopoLdd, self.TopoId)
-            usid = ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = lddrepair(ifthenelse(boolean(usid), ldd(5), self.TopoLdd))
+            ds = pcr.downstream(self.TopoLdd, self.TopoId)
+            usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
+            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
 
         # Used to seperate output per LandUse/management classes
         # OutZones = self.LandUse
-        # report(self.reallength,"rl.map")
-        # report(catchmentcells,"kk.map")
+        # pcr.report(self.reallength,"rl.map")
+        # pcr.report(catchmentcells,"kk.map")
         self.QMMConv = self.timestepsecs / (
             self.reallength * self.reallength * 0.001
         )  # m3/s --> mm
@@ -1010,9 +1011,9 @@ class WflowModel(DynamicModel):
         # Set DCL to riverlength if that is longer that the basic length calculated from grid
         drainlength = detdrainlength(self.TopoLdd, self.xl, self.yl)
 
-        self.DCL = max(drainlength, self.RiverLength)  # m
+        self.DCL = pcr.max(drainlength, self.RiverLength)  # m
         # Multiply with Factor (taken from upscaling operation, defaults to 1.0 if no map is supplied
-        self.DCL = self.DCL * max(1.0, self.RiverLengthFac)
+        self.DCL = self.DCL * pcr.max(1.0, self.RiverLengthFac)
 
         # water depth (m)
         # set width for kinematic wave to cell width for all cells
@@ -1020,17 +1021,17 @@ class WflowModel(DynamicModel):
         # However, in the main river we have real flow so set the width to the
         # width of the river
 
-        self.Bw = ifthenelse(self.River, self.RiverWidth, self.Bw)
+        self.Bw = pcr.ifthenelse(self.River, self.RiverWidth, self.Bw)
 
         # term for Alpha
-        self.AlpTerm = pow((self.N / (sqrt(self.Slope))), self.Beta)
+        self.AlpTerm = pow((self.N / (pcr.sqrt(self.Slope))), self.Beta)
         # power for Alpha
         self.AlpPow = (2.0 / 3.0) * self.Beta
         # initial approximation for Alpha
 
         # calculate catchmentsize
-        self.upsize = catchmenttotal(self.xl * self.yl, self.TopoLdd)
-        self.csize = areamaximum(self.upsize, self.TopoId)
+        self.upsize = pcr.catchmenttotal(self.xl * self.yl, self.TopoLdd)
+        self.csize = pcr.areamaximum(self.upsize, self.TopoId)
 
         self.SaveDir = os.path.join(self.Dir, self.runId)
         self.logger.info("Starting Dynamic run...")
@@ -1061,18 +1062,18 @@ class WflowModel(DynamicModel):
 
             self.WaterLevel = (
                 self.catchArea * 0
-            )  # cover(0.0) #: Water level in kinimatic wave (state variable [m])
+            )  # pcr.cover(0.0) #: Water level in kinimatic wave (state variable [m])
 
             # set initial storage values
             #            pdb.set_trace()
             self.Sa = [
-                0.05 * self.samax[i] * scalar(self.catchArea) for i in self.Classes
+                0.05 * self.samax[i] * pcr.scalar(self.catchArea) for i in self.Classes
             ]
             self.Su = [
-                self.sumax[i] * scalar(self.catchArea) for i in self.Classes
+                self.sumax[i] * pcr.scalar(self.catchArea) for i in self.Classes
             ]  # catchArea is nu het hele stroomgebied
             # TODO checken of catchArea aangepast moet worden naar TopoId
-            self.Ss = self.Ss + 30 * scalar(
+            self.Ss = self.Ss + 30 * pcr.scalar(
                 self.catchArea
             )  # for combined gw reservoir # 30 mm
 
@@ -1083,7 +1084,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSi[i]:
                     self.Si.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1097,7 +1098,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSw[i]:
                     self.Sw.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1111,7 +1112,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSa[i]:
                     self.Sa.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1125,7 +1126,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSu[i]:
                     self.Su.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1139,7 +1140,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSf[i]:
                     self.Sf.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1153,7 +1154,7 @@ class WflowModel(DynamicModel):
             for i in self.Classes:
                 if self.selectSfa[i]:
                     self.Sfa.append(
-                        readmap(
+                        pcr.readmap(
                             os.path.join(
                                 self.Dir,
                                 "instate",
@@ -1163,9 +1164,9 @@ class WflowModel(DynamicModel):
                     )
                 else:
                     self.Sfa.append(self.ZeroMap)
-            self.Ss = readmap(os.path.join(self.Dir, "instate", "Ss.map"))
-            self.Qstate = readmap(os.path.join(self.Dir, "instate", "Qstate.map"))
-            self.WaterLevel = readmap(
+            self.Ss = pcr.readmap(os.path.join(self.Dir, "instate", "Ss.map"))
+            self.Qstate = pcr.readmap(os.path.join(self.Dir, "instate", "Qstate.map"))
+            self.WaterLevel = pcr.readmap(
                 os.path.join(self.Dir, "instate", "WaterLevel.map")
             )
 
@@ -1256,24 +1257,24 @@ class WflowModel(DynamicModel):
         self.convQa_t = [copylist(self.convQa[i]) for i in self.Classes]
 
         if self.IRURFR_L:
-            self.PotEvaporation = areatotal(
-                self.PotEvaporation * self.percentArea, nominal(self.TopoId)
+            self.PotEvaporation = pcr.areatotal(
+                self.PotEvaporation * self.percentArea, pcr.nominal(self.TopoId)
             )
-            self.Precipitation = areatotal(
-                self.Precipitation * self.percentArea, nominal(self.TopoId)
+            self.Precipitation = pcr.areatotal(
+                self.Precipitation * self.percentArea, pcr.nominal(self.TopoId)
             )
-            self.Temperature = areaaverage(
-                self.Temperature * self.percentArea, nominal(self.TopoId)
+            self.Temperature = pcr.areaaverage(
+                self.Temperature * self.percentArea, pcr.nominal(self.TopoId)
             )
 
         self.PrecipTotal = (
             self.Precipitation
         )  # NB: self.PrecipTotal is the precipitation as in the inmaps and self.Precipitation is in fact self.Rainfall !!!!
         if self.selectSw[0] > 0:
-            self.Precipitation = ifthenelse(
+            self.Precipitation = pcr.ifthenelse(
                 self.Temperature >= self.Tt[0], self.PrecipTotal, 0
             )
-            self.PrecipitationSnow = ifthenelse(
+            self.PrecipitationSnow = pcr.ifthenelse(
                 self.Temperature < self.Tt[0], self.PrecipTotal, 0
             )
 
@@ -1374,125 +1375,125 @@ class WflowModel(DynamicModel):
         )
 
         #    #fuxes and states in m3/h
-        self.P = areatotal(
-            self.PrecipTotal / 1000 * self.surfaceArea, nominal(self.TopoId)
+        self.P = pcr.areatotal(
+            self.PrecipTotal / 1000 * self.surfaceArea, pcr.nominal(self.TopoId)
         )
-        self.Ei = areatotal(
+        self.Ei = pcr.areatotal(
             sum(multiply(self.Ei_, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Ea = areatotal(
+        self.Ea = pcr.areatotal(
             sum(multiply(self.Ea_, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Eu = areatotal(
+        self.Eu = pcr.areatotal(
             sum(multiply(self.Eu_, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Ew = areatotal(
+        self.Ew = pcr.areatotal(
             sum(multiply(self.Ew_, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.EwiCorr = areatotal(
+        self.EwiCorr = pcr.areatotal(
             sum(multiply(multiply(self.Ew_, self.lamdaS / self.lamda), self.percent))
             / 1000
             * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
         self.Qtot = self.QLagTot * self.timestepsecs
-        self.SiWB = areatotal(
+        self.SiWB = pcr.areatotal(
             sum(multiply(self.Si, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Si_WB = areatotal(
+        self.Si_WB = pcr.areatotal(
             sum(multiply(self.Si_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SuWB = areatotal(
+        self.SuWB = pcr.areatotal(
             sum(multiply(self.Su, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Su_WB = areatotal(
+        self.Su_WB = pcr.areatotal(
             sum(multiply(self.Su_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SaWB = areatotal(
+        self.SaWB = pcr.areatotal(
             sum(multiply(self.Sa, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Sa_WB = areatotal(
+        self.Sa_WB = pcr.areatotal(
             sum(multiply(self.Sa_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SfWB = areatotal(
+        self.SfWB = pcr.areatotal(
             sum(multiply(self.Sf, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Sf_WB = areatotal(
+        self.Sf_WB = pcr.areatotal(
             sum(multiply(self.Sf_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SfaWB = areatotal(
+        self.SfaWB = pcr.areatotal(
             sum(multiply(self.Sfa, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Sfa_WB = areatotal(
+        self.Sfa_WB = pcr.areatotal(
             sum(multiply(self.Sfa_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SwWB = areatotal(
+        self.SwWB = pcr.areatotal(
             sum(multiply(self.Sw, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.Sw_WB = areatotal(
+        self.Sw_WB = pcr.areatotal(
             sum(multiply(self.Sw_t, self.percent)) / 1000 * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.SsWB = areatotal(self.Ss / 1000 * self.surfaceArea, nominal(self.TopoId))
-        self.Ss_WB = areatotal(
-            self.Ss_t / 1000 * self.surfaceArea, nominal(self.TopoId)
+        self.SsWB = pcr.areatotal(self.Ss / 1000 * self.surfaceArea, pcr.nominal(self.TopoId))
+        self.Ss_WB = pcr.areatotal(
+            self.Ss_t / 1000 * self.surfaceArea, pcr.nominal(self.TopoId)
         )
-        self.convQuWB = areatotal(
+        self.convQuWB = pcr.areatotal(
             sum(multiply([sum(self.convQu[i]) for i in self.Classes], self.percent))
             / 1000
             * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.convQu_WB = areatotal(
+        self.convQu_WB = pcr.areatotal(
             sum(multiply([sum(self.convQu_t[i]) for i in self.Classes], self.percent))
             / 1000
             * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.convQaWB = areatotal(
+        self.convQaWB = pcr.areatotal(
             sum(multiply([sum(self.convQa[i]) for i in self.Classes], self.percent))
             / 1000
             * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.convQa_WB = areatotal(
+        self.convQa_WB = pcr.areatotal(
             sum(multiply([sum(self.convQa_t[i]) for i in self.Classes], self.percent))
             / 1000
             * self.surfaceArea,
-            nominal(self.TopoId),
+            pcr.nominal(self.TopoId),
         )
-        self.trackQWB = areatotal(sum(self.trackQ), nominal(self.TopoId))
-        self.trackQ_WB = areatotal(sum(self.trackQ_t), nominal(self.TopoId))
+        self.trackQWB = pcr.areatotal(sum(self.trackQ), pcr.nominal(self.TopoId))
+        self.trackQ_WB = pcr.areatotal(sum(self.trackQ_t), pcr.nominal(self.TopoId))
         if self.selectRout == "kinematic_wave_routing":
-            self.QstateWB = areatotal(
-                sum(self.Qstate_new) * self.timestepsecs, nominal(self.TopoId)
+            self.QstateWB = pcr.areatotal(
+                sum(self.Qstate_new) * self.timestepsecs, pcr.nominal(self.TopoId)
             )
         else:
-            self.QstateWB = areatotal(
-                sum(self.Qstate) * self.timestepsecs, nominal(self.TopoId)
+            self.QstateWB = pcr.areatotal(
+                sum(self.Qstate) * self.timestepsecs, pcr.nominal(self.TopoId)
             )  # dit moet Qstate_new zijn ipv Qstate als je met de kin wave werkt en waterbalans wilt laten sluiten TODO aanpassen zodat het nog steeds werkt voor eerdere routing !!!
-        self.Qstate_WB = areatotal(
-            sum(self.Qstate_t) * self.timestepsecs, nominal(self.TopoId)
+        self.Qstate_WB = pcr.areatotal(
+            sum(self.Qstate_t) * self.timestepsecs, pcr.nominal(self.TopoId)
         )
-        #        self.QstateWB = areatotal(sum(self.Qstate) * 0.0405, nominal(self.TopoId))
-        #        self.Qstate_WB = areatotal(sum(self.Qstate_t) * 0.0405, nominal(self.TopoId))
-        #        self.QstateWB = areatotal(self.Qstate, nominal(self.TopoId))
-        #        self.Qstate_WB = areatotal(self.Qstate_t, nominal(self.TopoId))
+        #        self.QstateWB = pcr.areatotal(sum(self.Qstate) * 0.0405, pcr.nominal(self.TopoId))
+        #        self.Qstate_WB = pcr.areatotal(sum(self.Qstate_t) * 0.0405, pcr.nominal(self.TopoId))
+        #        self.QstateWB = pcr.areatotal(self.Qstate, pcr.nominal(self.TopoId))
+        #        self.Qstate_WB = pcr.areatotal(self.Qstate_t, pcr.nominal(self.TopoId))
         #
         # WBtot in m3/s   -- volgens mij moet dit m3/h zijn ??? TODO!
         self.WBtot = (

--- a/wflow/wflow_topoflex.py
+++ b/wflow/wflow_topoflex.py
@@ -174,7 +174,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             rest = pcr.cover(pcr.readmap(mapname), default)
         else:
             if os.path.isfile(pathtotbl):
-                rest = pcr.cover(pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default)
+                rest = pcr.cover(
+                    pcr.lookupscalar(pathtotbl, landuse, subcatch, soil), default
+                )
                 self.logger.info("Creating map from table: " + pathtotbl)
             else:
                 self.logger.warning(
@@ -903,8 +905,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         )  # list * scalar ---> list wordt zoveel x gekopieerd als scalar.
 
         # initialise list for lag function
-        self.convQu = [[0 * pcr.scalar(self.catchArea)] * self.Tf[i] for i in self.Classes]
-        self.convQa = [[0 * pcr.scalar(self.catchArea)] * self.Tfa[i] for i in self.Classes]
+        self.convQu = [
+            [0 * pcr.scalar(self.catchArea)] * self.Tf[i] for i in self.Classes
+        ]
+        self.convQa = [
+            [0 * pcr.scalar(self.catchArea)] * self.Tfa[i] for i in self.Classes
+        ]
 
         if self.scalarInput:
             self.gaugesMap = pcr.nominal(
@@ -915,7 +921,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         )  # location of subcatchment
         self.OutputIdRunoff = pcr.boolean(
             pcr.ifthenelse(
-                self.gaugesR == 1, 1 * pcr.scalar(self.TopoId), 0 * pcr.scalar(self.TopoId)
+                self.gaugesR == 1,
+                1 * pcr.scalar(self.TopoId),
+                0 * pcr.scalar(self.TopoId),
             )
         )  # location of subcatchment
 
@@ -953,7 +961,8 @@ class WflowModel(pcraster.framework.DynamicModel):
         W = (
             (alf * (alf + 2.0) ** (0.6666666667)) ** (0.375)
             * Qscale ** (0.375)
-            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0))) ** (-0.1875)
+            * (pcr.max(0.0001, pcr.windowaverage(self.Slope, pcr.celllength() * 4.0)))
+            ** (-0.1875)
             * self.N ** (0.375)
         )
         # Use supplied riverwidth if possible, else calulate
@@ -978,7 +987,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.logger.info("Creating subcatchment-only drainage network (ldd)")
             ds = pcr.downstream(self.TopoLdd, self.TopoId)
             usid = pcr.ifthenelse(ds != self.TopoId, self.TopoId, 0)
-            self.TopoLdd = pcr.lddrepair(pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd))
+            self.TopoLdd = pcr.lddrepair(
+                pcr.ifthenelse(pcr.boolean(usid), pcr.ldd(5), self.TopoLdd)
+            )
 
         # Used to seperate output per LandUse/management classes
         # OutZones = self.LandUse
@@ -1449,7 +1460,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             sum(multiply(self.Sw_t, self.percent)) / 1000 * self.surfaceArea,
             pcr.nominal(self.TopoId),
         )
-        self.SsWB = pcr.areatotal(self.Ss / 1000 * self.surfaceArea, pcr.nominal(self.TopoId))
+        self.SsWB = pcr.areatotal(
+            self.Ss / 1000 * self.surfaceArea, pcr.nominal(self.TopoId)
+        )
         self.Ss_WB = pcr.areatotal(
             self.Ss_t / 1000 * self.surfaceArea, pcr.nominal(self.TopoId)
         )

--- a/wflow/wflow_topoflex.py
+++ b/wflow/wflow_topoflex.py
@@ -16,14 +16,11 @@ wflow_topoflex  -C case -R Runid -c inifile
 
 """
 
-
-import os
 import os.path
-import getopt
+from copy import deepcopy as copylist
 
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
-from copy import deepcopy as copylist
 
 # TODO: see below
 """

--- a/wflow/wflow_upscale.py
+++ b/wflow/wflow_upscale.py
@@ -42,14 +42,12 @@ run the wflow_prepare scripts twice to create the different models.
 """
 
 
-from wflow.wflow_lib import *
-
-
-import os, sys, shlex, time
-import os.path
-import glob
 import getopt
-import subprocess
+import glob
+import os.path
+import shlex
+
+from wflow.wflow_lib import *
 
 
 def usage(*args):

--- a/wflow/wflow_upscale.py
+++ b/wflow/wflow_upscale.py
@@ -188,12 +188,12 @@ def main():
 
     print("recreating static maps ...")
     # Create new ldd using old river network
-    dem = readmap(caseNameNew + "/staticmaps/wflow_dem.map")
+    dem = pcr.readmap(caseNameNew + "/staticmaps/wflow_dem.map")
     # orig low res river
-    riverburn = readmap(caseNameNew + "/staticmaps/wflow_river.map")
+    riverburn = pcr.readmap(caseNameNew + "/staticmaps/wflow_river.map")
     # save it
-    report(riverburn, caseNameNew + "/staticmaps/wflow_riverburnin.map")
-    demburn = cover(ifthen(boolean(riverburn), dem - 600), dem)
+    pcr.report(riverburn, caseNameNew + "/staticmaps/wflow_riverburnin.map")
+    demburn = pcr.cover(pcr.ifthen(pcr.boolean(riverburn), dem - 600), dem)
     print("Creating ldd...")
     ldd = lddcreate_save(
         caseNameNew + "/staticmaps/wflow_ldd.map", demburn, True, 10.0e35
@@ -201,12 +201,12 @@ def main():
     ## Find catchment (overall)
     outlet = find_outlet(ldd)
     sub = subcatch(ldd, outlet)
-    report(sub, caseNameNew + "/staticmaps/wflow_catchment.map")
-    report(outlet, caseNameNew + "/staticmaps/wflow_outlet.map")
+    pcr.report(sub, caseNameNew + "/staticmaps/wflow_catchment.map")
+    pcr.report(outlet, caseNameNew + "/staticmaps/wflow_outlet.map")
     # os.system("col2map --clone " + caseNameNew + "/staticmaps/wflow_subcatch.map " + caseNameNew + "/staticmaps/gauges.col " + caseNameNew + "/staticmaps/wflow_gauges.map")
-    gmap = readmap(caseNameNew + "/staticmaps/wflow_gauges.map")
+    gmap = pcr.readmap(caseNameNew + "/staticmaps/wflow_gauges.map")
     scatch = subcatch(ldd, gmap)
-    report(scatch, caseNameNew + "/staticmaps/wflow_subcatch.map")
+    pcr.report(scatch, caseNameNew + "/staticmaps/wflow_subcatch.map")
 
 
 if __name__ == "__main__":

--- a/wflow/wflow_w3ra.py
+++ b/wflow/wflow_w3ra.py
@@ -36,8 +36,10 @@ $Id: wflow_sceleton.py 898 2014-01-09 14:47:06Z schelle $
 $Rev: 898 $
 """
 
+import math
 import os.path
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -54,7 +56,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. T
   """
@@ -67,8 +69,8 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
 
       """
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -142,8 +144,8 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
-        setglobaloption("radians")  # Needed as W3RA was originally written in matlab
+        pcr.setglobaloption("unittrue")
+        pcr.setglobaloption("radians")  # Needed as W3RA was originally written in matlab
 
         # SET GLBOAL PARAMETER VALUES (however not used in original script)
         # Nhru=2
@@ -201,9 +203,9 @@ class WflowModel(DynamicModel):
             self.config, "inputmapstacks", "AIRPRESS", "/inmaps/PRES"
         )
 
-        self.Altitude = readmap(self.Dir + "/staticmaps/wflow_dem")
+        self.Altitude = pcr.readmap(self.Dir + "/staticmaps/wflow_dem")
 
-        self.latitude = ycoordinate(boolean(self.Altitude))
+        self.latitude = pcr.ycoordinate(pcr.boolean(self.Altitude))
 
         # Add reading of parameters here
 
@@ -406,8 +408,8 @@ class WflowModel(DynamicModel):
 
         self.wf_multparameters()
         # Static, for the computation of Aerodynamic conductance (3.7)
-        self.fh1 = ln(813.0 / self.hveg1 - 5.45)
-        self.fh2 = ln(813.0 / self.hveg2 - 5.45)
+        self.fh1 = pcr.ln(813.0 / self.hveg1 - 5.45)
+        self.fh2 = pcr.ln(813.0 / self.hveg2 - 5.45)
         self.ku2_1 = 0.305 / (self.fh1 * (self.fh1 + 2.3))
         self.ku2_2 = 0.305 / (self.fh2 * (self.fh2 + 2.3))
 
@@ -429,7 +431,7 @@ class WflowModel(DynamicModel):
         except:
             self.logger.warning("Cannot load initial states, setting to default")
             for s in self.stateVariables():
-                exec("self." + s + " = cover(1.0)")
+                exec("self." + s + " = pcr.cover(1.0)")
 
     def default_summarymaps(self):
         """
@@ -477,63 +479,63 @@ class WflowModel(DynamicModel):
         # Put the W3RA here. Stuff from W3RA_timestep_model.m
         # read meteo from file
         self.logger.debug("Running for: " + str(self.currentdatetime))
-        self.PRECIP = cover(
-            self.wf_readmap(self.PRECIP_mapstack, 0.0), scalar(0.0)
+        self.PRECIP = pcr.cover(
+            self.wf_readmap(self.PRECIP_mapstack, 0.0), pcr.scalar(0.0)
         )  # mm
 
         if self.UseETPdata == 1:
-            self.TDAY = cover(
-                self.wf_readmap(self.TDAY_mapstack, 10.0), scalar(10.0)
+            self.TDAY = pcr.cover(
+                self.wf_readmap(self.TDAY_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.EPOT = cover(
-                self.wf_readmap(self.EPOT_mapstack, 0.0), scalar(0.0)
+            self.EPOT = pcr.cover(
+                self.wf_readmap(self.EPOT_mapstack, 0.0), pcr.scalar(0.0)
             )  # mm
-            self.WINDSPEED = cover(
-                self.wf_readmap(self.WINDSPEED_mapstack, default=1.0), scalar(1.0)
+            self.WINDSPEED = pcr.cover(
+                self.wf_readmap(self.WINDSPEED_mapstack, default=1.0), pcr.scalar(1.0)
             )
-            self.AIRPRESS = cover(
-                self.wf_readmap(self.AIRPRESS_mapstack, default=980.0), scalar(980.0)
+            self.AIRPRESS = pcr.cover(
+                self.wf_readmap(self.AIRPRESS_mapstack, default=980.0), pcr.scalar(980.0)
             )
             # print "Using climatology for wind, air pressure and albedo."
         elif self.UseETPdata == 0:
-            self.TMIN = cover(
-                self.wf_readmap(self.TMIN_mapstack, 10.0), scalar(10.0)
+            self.TMIN = pcr.cover(
+                self.wf_readmap(self.TMIN_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.TMAX = cover(
-                self.wf_readmap(self.TMAX_mapstack, 10.0), scalar(10.0)
+            self.TMAX = pcr.cover(
+                self.wf_readmap(self.TMAX_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.RAD = cover(
-                self.wf_readmap(self.RAD_mapstack, 10.0), scalar(10.0)
+            self.RAD = pcr.cover(
+                self.wf_readmap(self.RAD_mapstack, 10.0), pcr.scalar(10.0)
             )  # W m-2 s-1
-            self.WINDSPEED = cover(
-                self.wf_readmap(self.WINDSPEED_mapstack, 10.0), scalar(10.0)
+            self.WINDSPEED = pcr.cover(
+                self.wf_readmap(self.WINDSPEED_mapstack, 10.0), pcr.scalar(10.0)
             )  # ms-1
-            self.AIRPRESS = cover(
-                self.wf_readmap(self.AIRPRESS_mapstack, 10.0), scalar(10.0)
+            self.AIRPRESS = pcr.cover(
+                self.wf_readmap(self.AIRPRESS_mapstack, 10.0), pcr.scalar(10.0)
             )  # Pa
-            self.ALBEDO = cover(
+            self.ALBEDO = pcr.cover(
                 self.wf_readmapClimatology(self.ALBEDO_mapstack, default=0.1),
-                scalar(0.1),
+                pcr.scalar(0.1),
             )
 
         self.wf_multparameters()
         doy = self.currentdatetime.timetuple().tm_yday
 
         # conversion daylength
-        setglobaloption("radians")
-        m = scalar(1) - tan((self.latitude * scalar(pi) / scalar(180))) * tan(
+        pcr.setglobaloption("radians")
+        m = pcr.scalar(1) - pcr.tan((self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))) * pcr.tan(
             (
-                (scalar(23.439) * scalar(pi) / scalar(180))
-                * cos(scalar(2) * scalar(pi) * (doy + scalar(9)) / scalar(365.25))
+                (pcr.scalar(23.439) * pcr.scalar(math.pi) / pcr.scalar(180))
+                * pcr.cos(pcr.scalar(2) * pcr.scalar(math.pi) * (doy + pcr.scalar(9)) / pcr.scalar(365.25))
             )
         )
-        self.fday = min(
-            max(
-                scalar(0.02),
-                scalar(acos(scalar(1) - min(max(scalar(0), m), scalar(2))))
-                / scalar(pi),
+        self.fday = pcr.min(
+            pcr.max(
+                pcr.scalar(0.02),
+                pcr.scalar(pcr.acos(pcr.scalar(1) - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))))
+                / pcr.scalar(math.pi),
             ),
-            scalar(1),
+            pcr.scalar(1),
         )  # fraction daylength
 
         # Assign forcing and estimate effective meteorological variables
@@ -544,24 +546,24 @@ class WflowModel(DynamicModel):
             Ta = self.TDAY  # T in degC
             T24 = self.TDAY  # T in degC
         elif self.UseETPdata == 0:
-            Rg = max(
-                self.RAD, scalar(0.0001)
+            Rg = pcr.max(
+                self.RAD, pcr.scalar(0.0001)
             )  # already in W m-2 s-1; set minimum of 0.01 to avoid numerical problems
-            Ta = self.TMIN + scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
-            T24 = self.TMIN + scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
-            pex = min(
-                scalar(17.27) * (self.TMIN) / (scalar(237.3) + self.TMIN), scalar(10)
+            Ta = self.TMIN + pcr.scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
+            T24 = self.TMIN + pcr.scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
+            pex = pcr.min(
+                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN), pcr.scalar(10)
             )  # T in degC
-            pe = min(
-                scalar(610.8) * (exp(pex)), scalar(10000.0)
+            pe = pcr.min(
+                pcr.scalar(610.8) * (pcr.exp(pex)), pcr.scalar(10000.0)
             )  # Mean actual vapour pressure, from dewpoint temperature
         # rescale factor because windspeed climatology is at 2m
         WindFactor = 1.0
-        # u2 = scalar(WindFactor)*self.WINDSPEED*(scalar(1)-(scalar(1)-self.fday)*scalar(0.25))/self.fday
+        # u2 = pcr.scalar(WindFactor)*self.WINDSPEED*(pcr.scalar(1)-(pcr.scalar(1)-self.fday)*scalar(0.25))/self.fday
         self.u2 = (
-            scalar(WindFactor)
+            pcr.scalar(WindFactor)
             * self.WINDSPEED
-            * (scalar(1) - (scalar(1) - self.fday) * scalar(0.25))
+            * (pcr.scalar(1) - (pcr.scalar(1) - self.fday) * pcr.scalar(0.25))
             / self.fday
         )
         pair = self.AIRPRESS  # already in Pa
@@ -570,10 +572,10 @@ class WflowModel(DynamicModel):
 
         self.LAI1 = self.SLA1 * self.Mleaf1  # (5.3)
         self.LAI2 = self.SLA2 * self.Mleaf2  # (5.3)
-        fveg1 = max(1 - exp(-self.LAI1 / self.LAIref1), 0.000001)  # (5.3)
-        fveg2 = max(1 - exp(-self.LAI2 / self.LAIref2), 0.000001)
+        fveg1 = pcr.max(1 - pcr.exp(-self.LAI1 / self.LAIref1), 0.000001)  # (5.3)
+        fveg2 = pcr.max(1 - pcr.exp(-self.LAI2 / self.LAIref2), 0.000001)
 
-        # Vc = max(0,EVI-0.07)/fveg
+        # Vc = pcr.max(0,EVI-0.07)/fveg
         fsoil1 = 1 - fveg1
         fsoil2 = 1 - fveg2
         w01 = self.S01 / self.S0FC1  # (2.1)
@@ -589,21 +591,21 @@ class WflowModel(DynamicModel):
         wSnow2 = self.FreeWater2 / (TotSnow2 + 1e-5)
 
         # Spatialise catchment fractions
-        Sgfree = max(self.Sg, 0.0)
+        Sgfree = pcr.max(self.Sg, 0.0)
         # JS: Not sure if this is translated properly....
         # for i=1:par.Nhru
-        fwater1 = min(0.005, (0.007 * self.Sr ** 0.75))
-        fwater2 = min(0.005, (0.007 * self.Sr ** 0.75))
-        fsat1 = min(1.0, max(min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
-        fsat2 = min(1.0, max(min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fwater1 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
+        fwater2 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
+        fsat1 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fsat2 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
         Sghru1 = self.Sg
         Sghru2 = self.Sg
 
         # CALCULATION OF PET
         # Conversions and coefficients (3.1)
-        pesx = min((scalar(17.27) * Ta / (scalar(237.3) + Ta)), scalar(10))
-        pes = min(
-            scalar((scalar(610.8)) * exp(pesx)), scalar(10000)
+        pesx = pcr.min((pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10))
+        pes = pcr.min(
+            pcr.scalar((pcr.scalar(610.8)) * pcr.exp(pesx)), pcr.scalar(10000)
         )  # saturated vapour pressure
         # fRH = pe/pes  # relative air humidity                                  -------------- check
         cRE = 0.03449 + 4.27e-5 * Ta
@@ -613,8 +615,8 @@ class WflowModel(DynamicModel):
         ga2 = self.ku2_2 * self.u2
 
         if self.UseETPdata == 1:
-            self.E01 = max(self.EPOT, 0)
-            self.E02 = max(self.EPOT, 0)
+            self.E01 = pcr.max(self.EPOT, 0)
+            self.E02 = pcr.max(self.EPOT, 0)
             keps = (
                 0.655e-3 * pair / pes
             )  # See Appendix A3 (http://www.clw.csiro.au/publications/waterforahealthycountry/2010/wfhc-aus-water-resources-assessment-system.pdf) --------------------------------   check!
@@ -630,10 +632,10 @@ class WflowModel(DynamicModel):
             # new equations for snow albedo
             alb_snow1 = 0.65 - 0.2 * wSnow1  # assumed; ideally some lit research needed
             alb_snow2 = 0.65 - 0.2 * wSnow2
-            fsnow1 = min(
+            fsnow1 = pcr.min(
                 1.0, 0.05 * TotSnow1
             )  # assumed; ideally some lit research needed
-            fsnow2 = min(1.0, 0.05 * TotSnow2)
+            fsnow2 = pcr.min(1.0, 0.05 * TotSnow2)
             # alb = fveg*alb_veg+(fsoil-fsnow)*alb_soil +fsnow*alb_snow
             # alb = albedo
             alb1 = (1 - fsnow1) * ns_alb + fsnow1 * alb_snow1
@@ -647,8 +649,8 @@ class WflowModel(DynamicModel):
             RLout = StefBolz * Tkelv ** 4.0  # (3.4)
             self.RLn = self.RLin - RLout
 
-            self.fGR1 = self.Gfrac_max1 * (1 - exp(-fsoil1 / self.fvegref_G1))
-            self.fGR2 = self.Gfrac_max2 * (1 - exp(-fsoil2 / self.fvegref_G2))  # (3.5)
+            self.fGR1 = self.Gfrac_max1 * (1 - pcr.exp(-fsoil1 / self.fvegref_G1))
+            self.fGR2 = self.Gfrac_max2 * (1 - pcr.exp(-fsoil2 / self.fvegref_G2))  # (3.5)
             self.Rneff1 = (RSn1 + self.RLn) * (1 - self.fGR1)
             self.Rneff2 = (RSn2 + self.RLn) * (1 - self.fGR2)
 
@@ -663,28 +665,28 @@ class WflowModel(DynamicModel):
             kalpha2 = 1 + Caero * ga2 / self.Rneff2
             self.E01 = cRE * (1 / (1 + keps)) * kalpha1 * self.Rneff1 * self.fday
             self.E02 = cRE * (1 / (1 + keps)) * kalpha2 * self.Rneff2 * self.fday
-            self.E01 = max(self.E01, 0)
-            self.E02 = max(self.E02, 0)
+            self.E01 = pcr.max(self.E01, 0)
+            self.E02 = pcr.max(self.E02, 0)
 
         # CALCULATION OF ET FLUXES AND ROOT WATER UPTAKE
         # Root water uptake constraint (4.4)
-        Usmax1 = max(
-            0, self.Us01 * min(1, ws1 / self.wslimU1)
+        Usmax1 = pcr.max(
+            0, self.Us01 * pcr.min(1, ws1 / self.wslimU1)
         )  ##0-waarden omdat ws1 bevat 0-waarden (zie regel 116)
-        Usmax2 = max(
-            0, self.Us02 * min(1, ws2 / self.wslimU2)
+        Usmax2 = pcr.max(
+            0, self.Us02 * pcr.min(1, ws2 / self.wslimU2)
         )  ##0-waarden omdat ws2 bevat 0-waarden (zie regel 117)
-        Udmax1 = max(
-            0, self.Ud01 * min(1, wd1 / self.wdlimU1)
+        Udmax1 = pcr.max(
+            0, self.Ud01 * pcr.min(1, wd1 / self.wdlimU1)
         )  ##0-waarden omdat wd1 bevat 0-waarden (zie regel 118)
-        Udmax2 = max(
-            0, self.Ud02 * min(1, wd2 / self.wdlimU2)
+        Udmax2 = pcr.max(
+            0, self.Ud02 * pcr.min(1, wd2 / self.wdlimU2)
         )  ##0-waarden omdat wd2 bevat 0-waarden (zie regel 119)
-        # U0max = max(0, Us0*min(1,w0/wslimU))
-        U0max1 = scalar(0)
-        U0max2 = scalar(0)
-        Utot1 = max(Usmax1, max(Udmax1, U0max1))
-        Utot2 = max(Usmax2, max(Udmax2, U0max2))
+        # U0max = pcr.max(0, Us0*min(1,w0/wslimU))
+        U0max1 = pcr.scalar(0)
+        U0max2 = pcr.scalar(0)
+        Utot1 = pcr.max(Usmax1, pcr.max(Udmax1, U0max1))
+        Utot2 = pcr.max(Usmax2, pcr.max(Udmax2, U0max2))
 
         # Maximum transpiration (4.3)
         Gsmax1 = self.cGsmax1 * self.Vc1
@@ -697,47 +699,47 @@ class WflowModel(DynamicModel):
         Etmax2 = ft2 * self.E02
 
         # Actual transpiration (4.1)
-        Et1 = min(Utot1, Etmax1)
-        Et2 = min(Utot2, Etmax2)
+        Et1 = pcr.min(Utot1, Etmax1)
+        Et2 = pcr.min(Utot2, Etmax2)
 
         # # Root water uptake distribution (2.3)
-        U01 = max(min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
-        Us1 = max(min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
-        Ud1 = max(min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
+        U01 = pcr.max(pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
+        Us1 = pcr.max(pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
+        Ud1 = pcr.max(pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
         Et1 = U01 + Us1 + Ud1  # to ensure mass balance
 
-        U02 = max(min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
-        Us2 = max(min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
-        Ud2 = max(min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
+        U02 = pcr.max(pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
+        Us2 = pcr.max(pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
+        Ud2 = pcr.max(pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
         Et2 = U02 + Us2 + Ud2
 
         # Soil evaporation (4.5)
-        self.S01 = max(0, self.S01 - U01)
-        self.S02 = max(0, self.S02 - U02)
+        self.S01 = pcr.max(0, self.S01 - U01)
+        self.S02 = pcr.max(0, self.S02 - U02)
         w01 = self.S01 / self.S0FC1  # (2.1)
         w02 = self.S02 / self.S0FC2  # (2.1)
-        fsoilE1 = self.FsoilEmax1 * min(1, w01 / self.w0limE1)
-        fsoilE2 = self.FsoilEmax2 * min(1, w02 / self.w0limE2)
-        Es1 = max(0, min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
-        Es2 = max(0, min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
+        fsoilE1 = self.FsoilEmax1 * pcr.min(1, w01 / self.w0limE1)
+        fsoilE2 = self.FsoilEmax2 * pcr.min(1, w02 / self.w0limE2)
+        Es1 = pcr.max(0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
+        Es2 = pcr.max(0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
         # Groundwater evaporation (4.6)
-        Eg1 = min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
-        Eg2 = min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
+        Eg1 = pcr.min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
+        Eg2 = pcr.min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
         # Open water evaporation (4.7)
-        Er1 = min(fwater1 * self.FwaterE1 * max(0, self.E01 - Et1), self.Sr)
-        Er2 = min(fwater2 * self.FwaterE2 * max(0, self.E02 - Et2), self.Sr)
+        Er1 = pcr.min(fwater1 * self.FwaterE1 * pcr.max(0, self.E01 - Et1), self.Sr)
+        Er2 = pcr.min(fwater2 * self.FwaterE2 * pcr.max(0, self.E02 - Et2), self.Sr)
         # Rainfall interception evaporation (4.2)
         Sveg1 = self.S_sls1 * self.LAI1
         fER1 = self.ER_frac_ref1 * fveg1
-        Pwet1 = -ln(1 - fER1 / fveg1) * Sveg1 / fER1
-        Ei1 = scalar(Pg < Pwet1) * fveg1 * Pg + scalar(Pg >= Pwet1) * (
+        Pwet1 = -pcr.ln(1 - fER1 / fveg1) * Sveg1 / fER1
+        Ei1 = pcr.scalar(Pg < Pwet1) * fveg1 * Pg + pcr.scalar(Pg >= Pwet1) * (
             fveg1 * Pwet1 + fER1 * (Pg - Pwet1)
         )
 
         Sveg2 = self.S_sls2 * self.LAI2
         fER2 = self.ER_frac_ref2 * fveg2
-        Pwet2 = -ln(1 - fER2 / fveg2) * Sveg2 / fER2
-        Ei2 = scalar(Pg < Pwet2) * fveg2 * Pg + scalar(Pg >= Pwet2) * (
+        Pwet2 = -pcr.ln(1 - fER2 / fveg2) * Sveg2 / fER2
+        Ei2 = pcr.scalar(Pg < Pwet2) * fveg2 * Pg + pcr.scalar(Pg >= Pwet2) * (
             fveg2 * Pwet2 + fER2 * (Pg - Pwet2)
         )
 
@@ -758,28 +760,28 @@ class WflowModel(DynamicModel):
         # Snow routine parameters
         # parameters
         # TODO: Check this, not sure if this works.......
-        x = scalar(Pg)
-        Cfmax1 = 0.6 * 3.75653 * scalar(x >= 0)
-        Cfmax2 = 3.75653 * scalar(x >= 0)
-        TT1 = -1.41934 * scalar(
+        x = pcr.scalar(Pg)
+        Cfmax1 = 0.6 * 3.75653 * pcr.scalar(x >= 0)
+        Cfmax2 = 3.75653 * pcr.scalar(x >= 0)
+        TT1 = -1.41934 * pcr.scalar(
             x >= 0
         )  # critical temperature for snowmelt and refreezing
-        TT2 = -1.41934 * scalar(x >= 0)
-        TTI1 = 1.00000 * scalar(
+        TT2 = -1.41934 * pcr.scalar(x >= 0)
+        TTI1 = 1.00000 * pcr.scalar(
             x >= 0
         )  # defines interval in which precipitation falls as rainfall and snowfall
-        TTI2 = 1.00000 * scalar(x >= 0)
-        CFR1 = 0.05000 * scalar(
+        TTI2 = 1.00000 * pcr.scalar(x >= 0)
+        CFR1 = 0.05000 * pcr.scalar(
             x >= 0
         )  # refreezing efficiency constant in refreezing of freewater in snow
-        CFR2 = 0.05000 * scalar(x >= 0)
-        WHC1 = 0.10000 * scalar(x >= 0)
-        WHC2 = 0.10000 * scalar(x >= 0)
+        CFR2 = 0.05000 * pcr.scalar(x >= 0)
+        WHC1 = 0.10000 * pcr.scalar(x >= 0)
+        WHC2 = 0.10000 * pcr.scalar(x >= 0)
 
         # Partitioning into fractions rain and snow
         Temperature = T24  # Dimmie, let op: tijdelijke regel!!
-        RainFrac1 = max(0, min((Temperature - (TT1 - TTI1 / 2)) / TTI1, 1))
-        RainFrac2 = max(0, min((Temperature - (TT2 - TTI2 / 2)) / TTI2, 1))
+        RainFrac1 = pcr.max(0, pcr.min((Temperature - (TT1 - TTI1 / 2)) / TTI1, 1))
+        RainFrac2 = pcr.max(0, pcr.min((Temperature - (TT2 - TTI2 / 2)) / TTI2, 1))
         SnowFrac1 = 1 - RainFrac1  # fraction of precipitation which falls as snow
         SnowFrac2 = 1 - RainFrac2
 
@@ -788,18 +790,18 @@ class WflowModel(DynamicModel):
         SnowFall2 = SnowFrac2 * Precipitation2
         RainFall1 = RainFrac1 * Precipitation1  # rainfall depth
         RainFall2 = RainFrac2 * Precipitation2
-        PotSnowMelt1 = Cfmax1 * max(
+        PotSnowMelt1 = Cfmax1 * pcr.max(
             0, Temperature - TT1
         )  # Potential snow melt, based on temperature
-        PotSnowMelt2 = Cfmax2 * max(0, Temperature - TT2)
+        PotSnowMelt2 = Cfmax2 * pcr.max(0, Temperature - TT2)
         PotRefreezing1 = (
-            Cfmax1 * CFR1 * max(TT1 - Temperature, 0)
+            Cfmax1 * CFR1 * pcr.max(TT1 - Temperature, 0)
         )  # Potential refreezing, based on temperature
-        PotRefreezing2 = Cfmax2 * CFR2 * max(TT2 - Temperature, 0)
-        Refreezing1 = min(PotRefreezing1, self.FreeWater1)  # actual refreezing
-        Refreezing2 = min(PotRefreezing2, self.FreeWater2)
-        SnowMelt1 = min(PotSnowMelt1, self.DrySnow1)  # actual snow melt
-        SnowMelt2 = min(PotSnowMelt2, self.DrySnow2)
+        PotRefreezing2 = Cfmax2 * CFR2 * pcr.max(TT2 - Temperature, 0)
+        Refreezing1 = pcr.min(PotRefreezing1, self.FreeWater1)  # actual refreezing
+        Refreezing2 = pcr.min(PotRefreezing2, self.FreeWater2)
+        SnowMelt1 = pcr.min(PotSnowMelt1, self.DrySnow1)  # actual snow melt
+        SnowMelt2 = pcr.min(PotSnowMelt2, self.DrySnow2)
         self.DrySnow1 = (
             self.DrySnow1 + SnowFall1 + Refreezing1 - SnowMelt1
         )  # dry snow content
@@ -810,18 +812,18 @@ class WflowModel(DynamicModel):
         MaxFreeWater2 = self.DrySnow2 * WHC2
         self.FreeWater1 = self.FreeWater1 + SnowMelt1 + RainFall1
         self.FreeWater2 = self.FreeWater2 + SnowMelt2 + RainFall2
-        InSoil1 = max(
+        InSoil1 = pcr.max(
             self.FreeWater1 - MaxFreeWater1, 0
         )  # abundant water in snow pack which goes into soil
-        InSoil2 = max(self.FreeWater2 - MaxFreeWater2, 0)
+        InSoil2 = pcr.max(self.FreeWater2 - MaxFreeWater2, 0)
         self.FreeWater1 = self.FreeWater1 - InSoil1
         self.FreeWater2 = self.FreeWater2 - InSoil2
         # End of Snow Module
 
         # CALCULATION OF WATER BALANCES
         # surface water fluxes (2.2)
-        NetInSoil1 = max(0, (InSoil1 - self.InitLoss1))
-        NetInSoil2 = max(0, (InSoil2 - self.InitLoss2))
+        NetInSoil1 = pcr.max(0, (InSoil1 - self.InitLoss1))
+        NetInSoil2 = pcr.max(0, (InSoil2 - self.InitLoss2))
         Rhof1 = (1 - fsat1) * (NetInSoil1 / (NetInSoil1 + self.PrefR1)) * NetInSoil1
         Rhof2 = (1 - fsat2) * (NetInSoil2 / (NetInSoil2 + self.PrefR2)) * NetInSoil2
         Rsof1 = fsat1 * NetInSoil1
@@ -838,19 +840,19 @@ class WflowModel(DynamicModel):
         SzFC2 = self.S0FC2
         Sz1 = self.S01
         Sz2 = self.S02
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
         self.TMP = SzFC1
 
         # TODO: Check if this works
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         D01 = Dz1
         D02 = Dz2
         self.S01 = self.S01 - D01
@@ -862,16 +864,16 @@ class WflowModel(DynamicModel):
         SzFC2 = self.SsFC2
         Sz1 = self.Ss1
         Sz2 = self.Ss2
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         Ds1 = Dz1
         Ds2 = Dz2
         self.Ss1 = self.Ss1 - Ds1
@@ -883,25 +885,25 @@ class WflowModel(DynamicModel):
         SzFC2 = self.SdFC2
         Sz1 = self.Sd1
         Sz2 = self.Sd2
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         Dd1 = Dz1
         Dd2 = Dz2
         self.Sd1 = self.Sd1 - Dd1
         self.Sd2 = self.Sd2 - Dd2
-        Y1 = min(
-            self.Fgw_conn1 * max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
+        Y1 = pcr.min(
+            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
         )
-        Y2 = min(
-            self.Fgw_conn2 * max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
+        Y2 = pcr.min(
+            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
         )
         # Y = Fgw_conn.*max(0,wdlimU.*SdFC-Sd); #nog matlab script
         self.Sd1 = self.Sd1 + Y1
@@ -911,43 +913,43 @@ class WflowModel(DynamicModel):
         # Groundwater store water balance (Sg) (2.5)
         NetGf = (self.Fhru1 * (Dd1 - Eg1 - Y1)) + (self.Fhru2 * (Dd2 - Eg2 - Y2))
         self.Sg = self.Sg + NetGf
-        Sgfree = max(self.Sg, 0)
-        Qg = min(Sgfree, (1 - exp(-self.K_gw)) * Sgfree)
+        Sgfree = pcr.max(self.Sg, 0)
+        Qg = pcr.min(Sgfree, (1 - pcr.exp(-self.K_gw)) * Sgfree)
         self.Sg = self.Sg - Qg
 
         # Surface water store water balance (Sr) (2.7)
         self.Sr = self.Sr + (self.Fhru1 * (QR1 - Er1)) + (self.Fhru2 * (QR2 - Er2)) + Qg
-        self.Qtot = min(self.Sr, (1 - exp(-self.K_rout)) * self.Sr)
+        self.Qtot = pcr.min(self.Sr, (1 - pcr.exp(-self.K_rout)) * self.Sr)
         self.Sr = self.Sr - self.Qtot
 
         # VEGETATION ADJUSTMENT (5)
 
         fveq1 = (
-            (1 / max((self.E01 / Utot1) - 1, 1e-3))
+            (1 / pcr.max((self.E01 / Utot1) - 1, 1e-3))
             * (keps / (1 + keps))
             * (ga1 / Gsmax1)
         )
         fveq2 = (
-            (1 / max((self.E02 / Utot2) - 1, 1e-3))
+            (1 / pcr.max((self.E02 / Utot2) - 1, 1e-3))
             * (keps / (1 + keps))
             * (ga2 / Gsmax2)
         )
-        fvmax1 = 1 - exp(-self.LAImax1 / self.LAIref1)
-        fvmax2 = 1 - exp(-self.LAImax2 / self.LAIref2)
-        fveq1 = min(fveq1, fvmax1)
-        fveq2 = min(fveq2, fvmax2)
-        dMleaf1 = -ln(1 - fveq1) * self.LAIref1 / self.SLA1 - self.Mleaf1
-        dMleaf2 = -ln(1 - fveq2) * self.LAIref2 / self.SLA2 - self.Mleaf2
+        fvmax1 = 1 - pcr.exp(-self.LAImax1 / self.LAIref1)
+        fvmax2 = 1 - pcr.exp(-self.LAImax2 / self.LAIref2)
+        fveq1 = pcr.min(fveq1, fvmax1)
+        fveq2 = pcr.min(fveq2, fvmax2)
+        dMleaf1 = -pcr.ln(1 - fveq1) * self.LAIref1 / self.SLA1 - self.Mleaf1
+        dMleaf2 = -pcr.ln(1 - fveq2) * self.LAIref2 / self.SLA2 - self.Mleaf2
 
         # Mleafnet1 = dMleaf1 * (dMleaf1/self.Tgrow1) + dMleaf1 * dMleaf1/self.Tsenc1
         # Mleafnet2 = dMleaf2 * (dMleaf1/self.Tgrow2) + dMleaf2 * dMleaf2/self.Tsenc2
         Mleafnet1 = (
-            scalar(dMleaf1 > 0) * (dMleaf1 / self.Tgrow1)
-            + scalar(dMleaf1 < 0) * dMleaf1 / self.Tsenc1
+            pcr.scalar(dMleaf1 > 0) * (dMleaf1 / self.Tgrow1)
+            + pcr.scalar(dMleaf1 < 0) * dMleaf1 / self.Tsenc1
         )
         Mleafnet2 = (
-            scalar(dMleaf2 > 0) * (dMleaf2 / self.Tgrow2)
-            + scalar(dMleaf2 < 0) * dMleaf2 / self.Tsenc2
+            pcr.scalar(dMleaf2 > 0) * (dMleaf2 / self.Tgrow2)
+            + pcr.scalar(dMleaf2 < 0) * dMleaf2 / self.Tsenc2
         )
 
         self.Mleaf1 = self.Mleaf1 + Mleafnet1
@@ -958,8 +960,8 @@ class WflowModel(DynamicModel):
         # Updating diagnostics
         self.LAI1 = self.SLA1 * self.Mleaf1  # (5.3)
         self.LAI2 = self.SLA2 * self.Mleaf2
-        fveg1 = 1 - exp(-self.LAI1 / self.LAIref1)  # (5.3)
-        fveg2 = 1 - exp(-self.LAI2 / self.LAIref2)
+        fveg1 = 1 - pcr.exp(-self.LAI1 / self.LAIref1)  # (5.3)
+        fveg2 = 1 - pcr.exp(-self.LAI2 / self.LAIref2)
         fsoil1 = 1 - fveg1
         fsoil2 = 1 - fveg2
         w01 = self.S01 / self.S0FC1  # (2.1)

--- a/wflow/wflow_w3ra.py
+++ b/wflow/wflow_w3ra.py
@@ -145,7 +145,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
         pcr.setglobaloption("unittrue")
-        pcr.setglobaloption("radians")  # Needed as W3RA was originally written in matlab
+        pcr.setglobaloption(
+            "radians"
+        )  # Needed as W3RA was originally written in matlab
 
         # SET GLBOAL PARAMETER VALUES (however not used in original script)
         # Nhru=2
@@ -494,7 +496,8 @@ class WflowModel(pcraster.framework.DynamicModel):
                 self.wf_readmap(self.WINDSPEED_mapstack, default=1.0), pcr.scalar(1.0)
             )
             self.AIRPRESS = pcr.cover(
-                self.wf_readmap(self.AIRPRESS_mapstack, default=980.0), pcr.scalar(980.0)
+                self.wf_readmap(self.AIRPRESS_mapstack, default=980.0),
+                pcr.scalar(980.0),
             )
             # print "Using climatology for wind, air pressure and albedo."
         elif self.UseETPdata == 0:
@@ -523,16 +526,28 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         # conversion daylength
         pcr.setglobaloption("radians")
-        m = pcr.scalar(1) - pcr.tan((self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))) * pcr.tan(
+        m = pcr.scalar(1) - pcr.tan(
+            (self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))
+        ) * pcr.tan(
             (
                 (pcr.scalar(23.439) * pcr.scalar(math.pi) / pcr.scalar(180))
-                * pcr.cos(pcr.scalar(2) * pcr.scalar(math.pi) * (doy + pcr.scalar(9)) / pcr.scalar(365.25))
+                * pcr.cos(
+                    pcr.scalar(2)
+                    * pcr.scalar(math.pi)
+                    * (doy + pcr.scalar(9))
+                    / pcr.scalar(365.25)
+                )
             )
         )
         self.fday = pcr.min(
             pcr.max(
                 pcr.scalar(0.02),
-                pcr.scalar(pcr.acos(pcr.scalar(1) - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))))
+                pcr.scalar(
+                    pcr.acos(
+                        pcr.scalar(1)
+                        - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))
+                    )
+                )
                 / pcr.scalar(math.pi),
             ),
             pcr.scalar(1),
@@ -552,7 +567,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             Ta = self.TMIN + pcr.scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
             T24 = self.TMIN + pcr.scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
             pex = pcr.min(
-                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN), pcr.scalar(10)
+                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN),
+                pcr.scalar(10),
             )  # T in degC
             pe = pcr.min(
                 pcr.scalar(610.8) * (pcr.exp(pex)), pcr.scalar(10000.0)
@@ -596,14 +612,20 @@ class WflowModel(pcraster.framework.DynamicModel):
         # for i=1:par.Nhru
         fwater1 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
         fwater2 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
-        fsat1 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
-        fsat2 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fsat1 = pcr.min(
+            1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref)
+        )
+        fsat2 = pcr.min(
+            1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref)
+        )
         Sghru1 = self.Sg
         Sghru2 = self.Sg
 
         # CALCULATION OF PET
         # Conversions and coefficients (3.1)
-        pesx = pcr.min((pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10))
+        pesx = pcr.min(
+            (pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10)
+        )
         pes = pcr.min(
             pcr.scalar((pcr.scalar(610.8)) * pcr.exp(pesx)), pcr.scalar(10000)
         )  # saturated vapour pressure
@@ -650,7 +672,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.RLn = self.RLin - RLout
 
             self.fGR1 = self.Gfrac_max1 * (1 - pcr.exp(-fsoil1 / self.fvegref_G1))
-            self.fGR2 = self.Gfrac_max2 * (1 - pcr.exp(-fsoil2 / self.fvegref_G2))  # (3.5)
+            self.fGR2 = self.Gfrac_max2 * (
+                1 - pcr.exp(-fsoil2 / self.fvegref_G2)
+            )  # (3.5)
             self.Rneff1 = (RSn1 + self.RLn) * (1 - self.fGR1)
             self.Rneff2 = (RSn2 + self.RLn) * (1 - self.fGR2)
 
@@ -703,14 +727,26 @@ class WflowModel(pcraster.framework.DynamicModel):
         Et2 = pcr.min(Utot2, Etmax2)
 
         # # Root water uptake distribution (2.3)
-        U01 = pcr.max(pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
-        Us1 = pcr.max(pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
-        Ud1 = pcr.max(pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
+        U01 = pcr.max(
+            pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0
+        )
+        Us1 = pcr.max(
+            pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0
+        )
+        Ud1 = pcr.max(
+            pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0
+        )
         Et1 = U01 + Us1 + Ud1  # to ensure mass balance
 
-        U02 = pcr.max(pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
-        Us2 = pcr.max(pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
-        Ud2 = pcr.max(pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
+        U02 = pcr.max(
+            pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0
+        )
+        Us2 = pcr.max(
+            pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0
+        )
+        Ud2 = pcr.max(
+            pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0
+        )
         Et2 = U02 + Us2 + Ud2
 
         # Soil evaporation (4.5)
@@ -720,8 +756,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         w02 = self.S02 / self.S0FC2  # (2.1)
         fsoilE1 = self.FsoilEmax1 * pcr.min(1, w01 / self.w0limE1)
         fsoilE2 = self.FsoilEmax2 * pcr.min(1, w02 / self.w0limE2)
-        Es1 = pcr.max(0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
-        Es2 = pcr.max(0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
+        Es1 = pcr.max(
+            0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2)
+        )
+        Es2 = pcr.max(
+            0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2)
+        )
         # Groundwater evaporation (4.6)
         Eg1 = pcr.min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
         Eg2 = pcr.min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
@@ -900,10 +940,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Sd1 = self.Sd1 - Dd1
         self.Sd2 = self.Sd2 - Dd2
         Y1 = pcr.min(
-            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
+            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1),
+            Sghru1 - Eg1,
         )
         Y2 = pcr.min(
-            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
+            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2),
+            Sghru2 - Eg2,
         )
         # Y = Fgw_conn.*max(0,wdlimU.*SdFC-Sd); #nog matlab script
         self.Sd1 = self.Sd1 + Y1

--- a/wflow/wflow_w3ra.py
+++ b/wflow/wflow_w3ra.py
@@ -36,12 +36,11 @@ $Id: wflow_sceleton.py 898 2014-01-09 14:47:06Z schelle $
 $Rev: 898 $
 """
 
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
+
 
 # TODO: Make the script HRU independent (loop over the nr of HRU's)
 # TODO:

--- a/wflow/wflow_w3ra_new.py
+++ b/wflow/wflow_w3ra_new.py
@@ -141,7 +141,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
         pcr.setglobaloption("unittrue")
-        pcr.setglobaloption("radians")  # Needed as W3RA was originally written in matlab
+        pcr.setglobaloption(
+            "radians"
+        )  # Needed as W3RA was originally written in matlab
 
         # SET GLBOAL PARAMETER VALUES (however not used in original script)
         # Nhru=2
@@ -519,16 +521,28 @@ class WflowModel(pcraster.framework.DynamicModel):
 
         # conversion daylength
         pcr.setglobaloption("radians")
-        m = pcr.scalar(1) - math.tan((self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))) * math.tan(
+        m = pcr.scalar(1) - math.tan(
+            (self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))
+        ) * math.tan(
             (
                 (pcr.scalar(23.439) * pcr.scalar(math.pi) / pcr.scalar(180))
-                * cos(pcr.scalar(2) * pcr.scalar(math.pi) * (doy + pcr.scalar(9)) / pcr.scalar(365.25))
+                * cos(
+                    pcr.scalar(2)
+                    * pcr.scalar(math.pi)
+                    * (doy + pcr.scalar(9))
+                    / pcr.scalar(365.25)
+                )
             )
         )
         self.fday = pcr.min(
             pcr.max(
                 pcr.scalar(0.02),
-                pcr.scalar(pcr.acos(pcr.scalar(1) - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))))
+                pcr.scalar(
+                    pcr.acos(
+                        pcr.scalar(1)
+                        - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))
+                    )
+                )
                 / pcr.scalar(math.pi),
             ),
             pcr.scalar(1),
@@ -548,7 +562,8 @@ class WflowModel(pcraster.framework.DynamicModel):
             Ta = self.TMIN + pcr.scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
             T24 = self.TMIN + pcr.scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
             pex = pcr.min(
-                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN), pcr.scalar(10)
+                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN),
+                pcr.scalar(10),
             )  # T in degC
             pe = pcr.min(
                 pcr.scalar(610.8) * (pcr.exp(pex)), pcr.scalar(10000.0)
@@ -597,14 +612,20 @@ class WflowModel(pcraster.framework.DynamicModel):
         # for i=1:par.Nhru
         fwater1 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
         fwater2 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
-        fsat1 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
-        fsat2 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fsat1 = pcr.min(
+            1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref)
+        )
+        fsat2 = pcr.min(
+            1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref)
+        )
         Sghru1 = self.Sg
         Sghru2 = self.Sg
 
         # CALCULATION OF PET
         # Conversions and coefficients (3.1)
-        pesx = pcr.min((pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10))
+        pesx = pcr.min(
+            (pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10)
+        )
         pes = pcr.min(
             pcr.scalar((pcr.scalar(610.8)) * pcr.exp(pesx)), pcr.scalar(10000)
         )  # saturated vapour pressure
@@ -650,7 +671,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.RLn = self.RLin - RLout
 
             self.fGR1 = self.Gfrac_max1 * (1 - pcr.exp(-fsoil1 / self.fvegref_G1))
-            self.fGR2 = self.Gfrac_max2 * (1 - pcr.exp(-fsoil2 / self.fvegref_G2))  # (3.5)
+            self.fGR2 = self.Gfrac_max2 * (
+                1 - pcr.exp(-fsoil2 / self.fvegref_G2)
+            )  # (3.5)
             self.Rneff1 = (RSn1 + self.RLn) * (1 - self.fGR1)
             self.Rneff2 = (RSn2 + self.RLn) * (1 - self.fGR2)
 
@@ -703,14 +726,26 @@ class WflowModel(pcraster.framework.DynamicModel):
         Et2 = pcr.min(Utot2, Etmax2)
 
         # # Root water uptake distribution (2.3)
-        U01 = pcr.max(pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
-        Us1 = pcr.max(pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
-        Ud1 = pcr.max(pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
+        U01 = pcr.max(
+            pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0
+        )
+        Us1 = pcr.max(
+            pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0
+        )
+        Ud1 = pcr.max(
+            pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0
+        )
         Et1 = U01 + Us1 + Ud1  # to ensure mass balance
 
-        U02 = pcr.max(pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
-        Us2 = pcr.max(pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
-        Ud2 = pcr.max(pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
+        U02 = pcr.max(
+            pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0
+        )
+        Us2 = pcr.max(
+            pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0
+        )
+        Ud2 = pcr.max(
+            pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0
+        )
         Et2 = U02 + Us2 + Ud2
 
         # Soil evaporation (4.5)
@@ -720,8 +755,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         w02 = self.S02 / self.S0FC2  # (2.1)
         fsoilE1 = self.FsoilEmax1 * pcr.min(1, w01 / self.w0limE1)
         fsoilE2 = self.FsoilEmax2 * pcr.min(1, w02 / self.w0limE2)
-        Es1 = pcr.max(0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
-        Es2 = pcr.max(0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
+        Es1 = pcr.max(
+            0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2)
+        )
+        Es2 = pcr.max(
+            0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2)
+        )
         # Groundwater evaporation (4.6)
         Eg1 = pcr.min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
         Eg2 = pcr.min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
@@ -896,10 +935,12 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.Sd1 = self.Sd1 - Dd1
         self.Sd2 = self.Sd2 - Dd2
         Y1 = pcr.min(
-            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
+            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1),
+            Sghru1 - Eg1,
         )
         Y2 = pcr.min(
-            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
+            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2),
+            Sghru2 - Eg2,
         )
         # Y = Fgw_conn.*max(0,wdlimU.*SdFC-Sd); #nog matlab script
         self.Sd1 = self.Sd1 + Y1

--- a/wflow/wflow_w3ra_new.py
+++ b/wflow/wflow_w3ra_new.py
@@ -32,12 +32,11 @@ $Id: wflow_sceleton.py 898 2014-01-09 14:47:06Z schelle $
 $Rev: 898 $
 """
 
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
+
 
 # TODO: Make the script HRU independent (loop over the nr of HRU's)
 # TODO:

--- a/wflow/wflow_w3ra_new.py
+++ b/wflow/wflow_w3ra_new.py
@@ -32,8 +32,10 @@ $Id: wflow_sceleton.py 898 2014-01-09 14:47:06Z schelle $
 $Rev: 898 $
 """
 
+import math
 import os.path
 
+import pcraster.framework
 from wflow.wf_DynamicFramework import *
 from wflow.wflow_adapt import *
 
@@ -50,7 +52,7 @@ def usage(*args):
     sys.exit(0)
 
 
-class WflowModel(DynamicModel):
+class WflowModel(pcraster.framework.DynamicModel):
     """
   The user defined model class. T
   """
@@ -63,8 +65,8 @@ class WflowModel(DynamicModel):
       may be added by you if needed.
       
       """
-        DynamicModel.__init__(self)
-        setclone(Dir + "/staticmaps/" + cloneMap)
+        pcraster.framework.DynamicModel.__init__(self)
+        pcr.setclone(Dir + "/staticmaps/" + cloneMap)
         self.runId = RunDir
         self.caseName = Dir
         self.Dir = Dir
@@ -138,8 +140,8 @@ class WflowModel(DynamicModel):
     """
         #: pcraster option to calculate with units or cells. Not really an issue
         #: in this model but always good to keep in mind.
-        setglobaloption("unittrue")
-        setglobaloption("radians")  # Needed as W3RA was originally written in matlab
+        pcr.setglobaloption("unittrue")
+        pcr.setglobaloption("radians")  # Needed as W3RA was originally written in matlab
 
         # SET GLBOAL PARAMETER VALUES (however not used in original script)
         # Nhru=2
@@ -203,9 +205,9 @@ class WflowModel(DynamicModel):
         # self.WINDSPEED_mapstack=self.Dir + configget(self.config,"inputmapstacks","WINDSPEED","/inmaps/WIND")
         # self.AIRPRESS_mapstack=self.Dir + configget(self.config,"inputmapstacks","AIRPRESS","/inmaps/PRES")
 
-        self.Altitude = readmap(self.Dir + "/staticmaps/wflow_dem")
+        self.Altitude = pcr.readmap(self.Dir + "/staticmaps/wflow_dem")
 
-        self.latitude = ycoordinate(boolean(self.Altitude))
+        self.latitude = pcr.ycoordinate(pcr.boolean(self.Altitude))
 
         # Add reading of parameters here
 
@@ -408,8 +410,8 @@ class WflowModel(DynamicModel):
 
         self.wf_multparameters()
         # Static, for the computation of Aerodynamic conductance (3.7)
-        self.fh1 = ln(813.0 / self.hveg1 - 5.45)
-        self.fh2 = ln(813.0 / self.hveg2 - 5.45)
+        self.fh1 = pcr.ln(813.0 / self.hveg1 - 5.45)
+        self.fh2 = pcr.ln(813.0 / self.hveg2 - 5.45)
         self.ku2_1 = 0.305 / (self.fh1 * (self.fh1 + 2.3))
         self.ku2_2 = 0.305 / (self.fh2 * (self.fh2 + 2.3))
 
@@ -431,7 +433,7 @@ class WflowModel(DynamicModel):
         except:
             self.logger.warning("Cannot load initial states, setting to default")
             for s in self.stateVariables():
-                exec("self." + s + " = cover(1.0)")
+                exec("self." + s + " = pcr.cover(1.0)")
 
     def default_summarymaps(self):
         """
@@ -477,59 +479,59 @@ class WflowModel(DynamicModel):
         # Put the W3RA here. Stuff from W3RA_timestep_model.m
         # read meteo from file
         self.logger.debug("Running for: " + str(self.currentdatetime))
-        self.PRECIP = cover(
-            self.wf_readmap(self.PRECIP_mapstack, 0.0), scalar(0.0)
+        self.PRECIP = pcr.cover(
+            self.wf_readmap(self.PRECIP_mapstack, 0.0), pcr.scalar(0.0)
         )  # mm
 
         if self.UseETPdata == 1:
-            self.TDAY = cover(
-                self.wf_readmap(self.TDAY_mapstack, 10.0), scalar(10.0)
+            self.TDAY = pcr.cover(
+                self.wf_readmap(self.TDAY_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.EPOT = cover(
-                self.wf_readmap(self.EPOT_mapstack, 0.0), scalar(0.0)
+            self.EPOT = pcr.cover(
+                self.wf_readmap(self.EPOT_mapstack, 0.0), pcr.scalar(0.0)
             )  # mm
-            # self.WINDSPEED=cover(self.wf_readmapClimatology(self.WINDSPEED_mapstack, default=1.0), scalar(1.0))
-            # self.AIRPRESS=cover(self.wf_readmapClimatology(self.AIRPRESS_mapstack, default=980.0), scalar(980.0))
+            # self.WINDSPEED=pcr.cover(self.wf_readmapClimatology(self.WINDSPEED_mapstack, default=1.0), pcr.scalar(1.0))
+            # self.AIRPRESS=pcr.cover(self.wf_readmapClimatology(self.AIRPRESS_mapstack, default=980.0), pcr.scalar(980.0))
             # print "Using climatology for wind, air pressure and albedo."
         elif self.UseETPdata == 0:
-            self.TMIN = cover(
-                self.wf_readmap(self.TMIN_mapstack, 10.0), scalar(10.0)
+            self.TMIN = pcr.cover(
+                self.wf_readmap(self.TMIN_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.TMAX = cover(
-                self.wf_readmap(self.TMAX_mapstack, 10.0), scalar(10.0)
+            self.TMAX = pcr.cover(
+                self.wf_readmap(self.TMAX_mapstack, 10.0), pcr.scalar(10.0)
             )  # T in degC
-            self.RAD = cover(
-                self.wf_readmap(self.RAD_mapstack, 10.0), scalar(10.0)
+            self.RAD = pcr.cover(
+                self.wf_readmap(self.RAD_mapstack, 10.0), pcr.scalar(10.0)
             )  # W m-2 s-1
-            self.WINDSPEED = cover(
-                self.wf_readmap(self.WINDSPEED_mapstack, 10.0), scalar(10.0)
+            self.WINDSPEED = pcr.cover(
+                self.wf_readmap(self.WINDSPEED_mapstack, 10.0), pcr.scalar(10.0)
             )  # ms-1
-            self.AIRPRESS = cover(
-                self.wf_readmap(self.AIRPRESS_mapstack, 10.0), scalar(10.0)
+            self.AIRPRESS = pcr.cover(
+                self.wf_readmap(self.AIRPRESS_mapstack, 10.0), pcr.scalar(10.0)
             )  # Pa
-            self.ALBEDO = cover(
+            self.ALBEDO = pcr.cover(
                 self.wf_readmapClimatology(self.ALBEDO_mapstack, default=0.1),
-                scalar(0.1),
+                pcr.scalar(0.1),
             )
 
         self.wf_multparameters()
         doy = self.currentdatetime.timetuple().tm_yday
 
         # conversion daylength
-        setglobaloption("radians")
-        m = scalar(1) - tan((self.latitude * scalar(pi) / scalar(180))) * tan(
+        pcr.setglobaloption("radians")
+        m = pcr.scalar(1) - math.tan((self.latitude * pcr.scalar(math.pi) / pcr.scalar(180))) * math.tan(
             (
-                (scalar(23.439) * scalar(pi) / scalar(180))
-                * cos(scalar(2) * scalar(pi) * (doy + scalar(9)) / scalar(365.25))
+                (pcr.scalar(23.439) * pcr.scalar(math.pi) / pcr.scalar(180))
+                * cos(pcr.scalar(2) * pcr.scalar(math.pi) * (doy + pcr.scalar(9)) / pcr.scalar(365.25))
             )
         )
-        self.fday = min(
-            max(
-                scalar(0.02),
-                scalar(acos(scalar(1) - min(max(scalar(0), m), scalar(2))))
-                / scalar(pi),
+        self.fday = pcr.min(
+            pcr.max(
+                pcr.scalar(0.02),
+                pcr.scalar(pcr.acos(pcr.scalar(1) - pcr.min(pcr.max(pcr.scalar(0), m), pcr.scalar(2))))
+                / pcr.scalar(math.pi),
             ),
-            scalar(1),
+            pcr.scalar(1),
         )  # fraction daylength
 
         # Assign forcing and estimate effective meteorological variables
@@ -540,29 +542,29 @@ class WflowModel(DynamicModel):
             Ta = self.TDAY  # T in degC
             T24 = self.TDAY  # T in degC
         elif self.UseETPdata == 0:
-            Rg = max(
-                self.RAD, scalar(0.0001)
+            Rg = pcr.max(
+                self.RAD, pcr.scalar(0.0001)
             )  # already in W m-2 s-1; set minimum of 0.01 to avoid numerical problems
-            Ta = self.TMIN + scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
-            T24 = self.TMIN + scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
-            pex = min(
-                scalar(17.27) * (self.TMIN) / (scalar(237.3) + self.TMIN), scalar(10)
+            Ta = self.TMIN + pcr.scalar(0.75) * (self.TMAX - self.TMIN)  # T in degC
+            T24 = self.TMIN + pcr.scalar(0.5) * (self.TMAX - self.TMIN)  # T in degC
+            pex = pcr.min(
+                pcr.scalar(17.27) * (self.TMIN) / (pcr.scalar(237.3) + self.TMIN), pcr.scalar(10)
             )  # T in degC
-            pe = min(
-                scalar(610.8) * (exp(pex)), scalar(10000.0)
+            pe = pcr.min(
+                pcr.scalar(610.8) * (pcr.exp(pex)), pcr.scalar(10000.0)
             )  # Mean actual vapour pressure, from dewpoint temperature
         # rescale factor because windspeed climatology is at 2m
         WindFactor = 1.0
         u2 = (
-            scalar(WindFactor)
+            pcr.scalar(WindFactor)
             * self.WINDSPEED
-            * (scalar(1) - (scalar(1) - self.fday) * scalar(0.25))
+            * (pcr.scalar(1) - (pcr.scalar(1) - self.fday) * pcr.scalar(0.25))
             / self.fday
         )
         self.u2 = (
-            scalar(WindFactor)
+            pcr.scalar(WindFactor)
             * self.WINDSPEED
-            * (scalar(1) - (scalar(1) - self.fday) * scalar(0.25))
+            * (pcr.scalar(1) - (pcr.scalar(1) - self.fday) * pcr.scalar(0.25))
             / self.fday
         )
         pair = self.AIRPRESS  # already in Pa
@@ -571,10 +573,10 @@ class WflowModel(DynamicModel):
 
         self.LAI1 = self.SLA1 * self.Mleaf1  # (5.3)
         self.LAI2 = self.SLA2 * self.Mleaf2  # (5.3)
-        fveg1 = max(1 - exp(-self.LAI1 / self.LAIref1), 0.000001)  # (5.3)
-        fveg2 = max(1 - exp(-self.LAI2 / self.LAIref2), 0.000001)
+        fveg1 = pcr.max(1 - pcr.exp(-self.LAI1 / self.LAIref1), 0.000001)  # (5.3)
+        fveg2 = pcr.max(1 - pcr.exp(-self.LAI2 / self.LAIref2), 0.000001)
 
-        # Vc = max(0,EVI-0.07)/fveg
+        # Vc = pcr.max(0,EVI-0.07)/fveg
         fsoil1 = 1 - fveg1
         fsoil2 = 1 - fveg2
         w01 = self.S01 / self.S0FC1  # (2.1)
@@ -590,21 +592,21 @@ class WflowModel(DynamicModel):
         wSnow2 = self.FreeWater2 / (TotSnow2 + 1e-5)
 
         # Spatialise catchment fractions
-        Sgfree = max(self.Sg, 0.0)
+        Sgfree = pcr.max(self.Sg, 0.0)
         # JS: Not sure if this is translated properly....
         # for i=1:par.Nhru
-        fwater1 = min(0.005, (0.007 * self.Sr ** 0.75))
-        fwater2 = min(0.005, (0.007 * self.Sr ** 0.75))
-        fsat1 = min(1.0, max(min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
-        fsat2 = min(1.0, max(min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fwater1 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
+        fwater2 = pcr.min(0.005, (0.007 * self.Sr ** 0.75))
+        fsat1 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
+        fsat2 = pcr.min(1.0, pcr.max(pcr.min(0.005, 0.007 * self.Sr ** 0.75), Sgfree / self.Sgref))
         Sghru1 = self.Sg
         Sghru2 = self.Sg
 
         # CALCULATION OF PET
         # Conversions and coefficients (3.1)
-        pesx = min((scalar(17.27) * Ta / (scalar(237.3) + Ta)), scalar(10))
-        pes = min(
-            scalar((scalar(610.8)) * exp(pesx)), scalar(10000)
+        pesx = pcr.min((pcr.scalar(17.27) * Ta / (pcr.scalar(237.3) + Ta)), pcr.scalar(10))
+        pes = pcr.min(
+            pcr.scalar((pcr.scalar(610.8)) * pcr.exp(pesx)), pcr.scalar(10000)
         )  # saturated vapour pressure
         # fRH = pe/pes  # relative air humidity                                  -------------- check
         cRE = 0.03449 + 4.27e-5 * Ta
@@ -615,8 +617,8 @@ class WflowModel(DynamicModel):
         ga2 = self.ku2_2 * u2
 
         if self.UseETPdata == 1:
-            self.E01 = max(self.EPOT, 0)
-            self.E02 = max(self.EPOT, 0)
+            self.E01 = pcr.max(self.EPOT, 0)
+            self.E02 = pcr.max(self.EPOT, 0)
             keps = (
                 0.655e-3 * pair / pes
             )  # See Appendix A3 (http://www.clw.csiro.au/publications/waterforahealthycountry/2010/wfhc-aus-water-resources-assessment-system.pdf) --------------------------------   check!
@@ -630,10 +632,10 @@ class WflowModel(DynamicModel):
             # new equations for snow albedo
             alb_snow1 = 0.65 - 0.2 * wSnow1  # assumed; ideally some lit research needed
             alb_snow2 = 0.65 - 0.2 * wSnow2
-            fsnow1 = min(
+            fsnow1 = pcr.min(
                 1.0, 0.05 * TotSnow1
             )  # assumed; ideally some lit research needed
-            fsnow2 = min(1.0, 0.05 * TotSnow2)
+            fsnow2 = pcr.min(1.0, 0.05 * TotSnow2)
             # alb = fveg*alb_veg+(fsoil-fsnow)*alb_soil +fsnow*alb_snow
             # alb = albedo
             alb1 = (1 - fsnow1) * ns_alb + fsnow1 * alb_snow1
@@ -647,8 +649,8 @@ class WflowModel(DynamicModel):
             RLout = StefBolz * Tkelv ** 4.0  # (3.4)
             self.RLn = self.RLin - RLout
 
-            self.fGR1 = self.Gfrac_max1 * (1 - exp(-fsoil1 / self.fvegref_G1))
-            self.fGR2 = self.Gfrac_max2 * (1 - exp(-fsoil2 / self.fvegref_G2))  # (3.5)
+            self.fGR1 = self.Gfrac_max1 * (1 - pcr.exp(-fsoil1 / self.fvegref_G1))
+            self.fGR2 = self.Gfrac_max2 * (1 - pcr.exp(-fsoil2 / self.fvegref_G2))  # (3.5)
             self.Rneff1 = (RSn1 + self.RLn) * (1 - self.fGR1)
             self.Rneff2 = (RSn2 + self.RLn) * (1 - self.fGR2)
 
@@ -663,28 +665,28 @@ class WflowModel(DynamicModel):
             kalpha2 = 1 + Caero * ga2 / self.Rneff2
             self.E01 = cRE * (1 / (1 + keps)) * kalpha1 * self.Rneff1 * self.fday
             self.E02 = cRE * (1 / (1 + keps)) * kalpha2 * self.Rneff2 * self.fday
-            self.E01 = max(self.E01, 0)
-            self.E02 = max(self.E02, 0)
+            self.E01 = pcr.max(self.E01, 0)
+            self.E02 = pcr.max(self.E02, 0)
 
         # CALCULATION OF ET FLUXES AND ROOT WATER UPTAKE
         # Root water uptake constraint (4.4)
-        Usmax1 = max(
-            0, self.Us01 * min(1, ws1 / self.wslimU1)
+        Usmax1 = pcr.max(
+            0, self.Us01 * pcr.min(1, ws1 / self.wslimU1)
         )  ##0-waarden omdat ws1 bevat 0-waarden (zie regel 116)
-        Usmax2 = max(
-            0, self.Us02 * min(1, ws2 / self.wslimU2)
+        Usmax2 = pcr.max(
+            0, self.Us02 * pcr.min(1, ws2 / self.wslimU2)
         )  ##0-waarden omdat ws2 bevat 0-waarden (zie regel 117)
-        Udmax1 = max(
-            0, self.Ud01 * min(1, wd1 / self.wdlimU1)
+        Udmax1 = pcr.max(
+            0, self.Ud01 * pcr.min(1, wd1 / self.wdlimU1)
         )  ##0-waarden omdat wd1 bevat 0-waarden (zie regel 118)
-        Udmax2 = max(
-            0, self.Ud02 * min(1, wd2 / self.wdlimU2)
+        Udmax2 = pcr.max(
+            0, self.Ud02 * pcr.min(1, wd2 / self.wdlimU2)
         )  ##0-waarden omdat wd2 bevat 0-waarden (zie regel 119)
-        # U0max = max(0, Us0*min(1,w0/wslimU))
-        U0max1 = scalar(0)
-        U0max2 = scalar(0)
-        Utot1 = max(Usmax1, max(Udmax1, U0max1))
-        Utot2 = max(Usmax2, max(Udmax2, U0max2))
+        # U0max = pcr.max(0, Us0*min(1,w0/wslimU))
+        U0max1 = pcr.scalar(0)
+        U0max2 = pcr.scalar(0)
+        Utot1 = pcr.max(Usmax1, pcr.max(Udmax1, U0max1))
+        Utot2 = pcr.max(Usmax2, pcr.max(Udmax2, U0max2))
 
         # Maximum transpiration (4.3)
         Gsmax1 = self.cGsmax1 * self.Vc1
@@ -697,47 +699,47 @@ class WflowModel(DynamicModel):
         Etmax2 = ft2 * self.E02
 
         # Actual transpiration (4.1)
-        Et1 = min(Utot1, Etmax1)
-        Et2 = min(Utot2, Etmax2)
+        Et1 = pcr.min(Utot1, Etmax1)
+        Et2 = pcr.min(Utot2, Etmax2)
 
         # # Root water uptake distribution (2.3)
-        U01 = max(min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
-        Us1 = max(min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
-        Ud1 = max(min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
+        U01 = pcr.max(pcr.min((U0max1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.S01 - 1e-2), 0)
+        Us1 = pcr.max(pcr.min((Usmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Ss1 - 1e-2), 0)
+        Ud1 = pcr.max(pcr.min((Udmax1 / (U0max1 + Usmax1 + Udmax1)) * Et1, self.Sd1 - 1e-2), 0)
         Et1 = U01 + Us1 + Ud1  # to ensure mass balance
 
-        U02 = max(min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
-        Us2 = max(min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
-        Ud2 = max(min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
+        U02 = pcr.max(pcr.min((U0max2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.S02 - 1e-2), 0)
+        Us2 = pcr.max(pcr.min((Usmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Ss2 - 1e-2), 0)
+        Ud2 = pcr.max(pcr.min((Udmax2 / (U0max2 + Usmax2 + Udmax2)) * Et2, self.Sd2 - 1e-2), 0)
         Et2 = U02 + Us2 + Ud2
 
         # Soil evaporation (4.5)
-        self.S01 = max(0, self.S01 - U01)
-        self.S02 = max(0, self.S02 - U02)
+        self.S01 = pcr.max(0, self.S01 - U01)
+        self.S02 = pcr.max(0, self.S02 - U02)
         w01 = self.S01 / self.S0FC1  # (2.1)
         w02 = self.S02 / self.S0FC2  # (2.1)
-        fsoilE1 = self.FsoilEmax1 * min(1, w01 / self.w0limE1)
-        fsoilE2 = self.FsoilEmax2 * min(1, w02 / self.w0limE2)
-        Es1 = max(0, min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
-        Es2 = max(0, min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
+        fsoilE1 = self.FsoilEmax1 * pcr.min(1, w01 / self.w0limE1)
+        fsoilE2 = self.FsoilEmax2 * pcr.min(1, w02 / self.w0limE2)
+        Es1 = pcr.max(0, pcr.min(((1 - fsat1) * fsoilE1 * (self.E01 - Et1)), self.S01 - 1e-2))
+        Es2 = pcr.max(0, pcr.min(((1 - fsat2) * fsoilE2 * (self.E02 - Et2)), self.S02 - 1e-2))
         # Groundwater evaporation (4.6)
-        Eg1 = min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
-        Eg2 = min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
+        Eg1 = pcr.min((fsat1 - fwater1) * self.FsoilEmax1 * (self.E01 - Et1), Sghru1)
+        Eg2 = pcr.min((fsat2 - fwater2) * self.FsoilEmax2 * (self.E02 - Et2), Sghru2)
         # Open water evaporation (4.7)
-        Er1 = min(fwater1 * self.FwaterE1 * max(0, self.E01 - Et1), self.Sr)
-        Er2 = min(fwater2 * self.FwaterE2 * max(0, self.E02 - Et2), self.Sr)
+        Er1 = pcr.min(fwater1 * self.FwaterE1 * pcr.max(0, self.E01 - Et1), self.Sr)
+        Er2 = pcr.min(fwater2 * self.FwaterE2 * pcr.max(0, self.E02 - Et2), self.Sr)
         # Rainfall interception evaporation (4.2)
         Sveg1 = self.S_sls1 * self.LAI1
         fER1 = self.ER_frac_ref1 * fveg1
-        Pwet1 = -ln(1 - fER1 / fveg1) * Sveg1 / fER1
-        Ei1 = scalar(Pg < Pwet1) * fveg1 * Pg + scalar(Pg >= Pwet1) * (
+        Pwet1 = -pcr.ln(1 - fER1 / fveg1) * Sveg1 / fER1
+        Ei1 = pcr.scalar(Pg < Pwet1) * fveg1 * Pg + pcr.scalar(Pg >= Pwet1) * (
             fveg1 * Pwet1 + fER1 * (Pg - Pwet1)
         )
 
         Sveg2 = self.S_sls2 * self.LAI2
         fER2 = self.ER_frac_ref2 * fveg2
-        Pwet2 = -ln(1 - fER2 / fveg2) * Sveg2 / fER2
-        Ei2 = scalar(Pg < Pwet2) * fveg2 * Pg + scalar(Pg >= Pwet2) * (
+        Pwet2 = -pcr.ln(1 - fER2 / fveg2) * Sveg2 / fER2
+        Ei2 = pcr.scalar(Pg < Pwet2) * fveg2 * Pg + pcr.scalar(Pg >= Pwet2) * (
             fveg2 * Pwet2 + fER2 * (Pg - Pwet2)
         )
 
@@ -754,28 +756,28 @@ class WflowModel(DynamicModel):
         # Snow routine parameters
         # parameters
         # TODO: Check this, not sure if this works.......
-        x = scalar(Pg)
-        Cfmax1 = 0.6 * 3.75653 * scalar(x >= 0)
-        Cfmax2 = 3.75653 * scalar(x >= 0)
-        TT1 = -1.41934 * scalar(
+        x = pcr.scalar(Pg)
+        Cfmax1 = 0.6 * 3.75653 * pcr.scalar(x >= 0)
+        Cfmax2 = 3.75653 * pcr.scalar(x >= 0)
+        TT1 = -1.41934 * pcr.scalar(
             x >= 0
         )  # critical temperature for snowmelt and refreezing
-        TT2 = -1.41934 * scalar(x >= 0)
-        TTI1 = 1.00000 * scalar(
+        TT2 = -1.41934 * pcr.scalar(x >= 0)
+        TTI1 = 1.00000 * pcr.scalar(
             x >= 0
         )  # defines interval in which precipitation falls as rainfall and snowfall
-        TTI2 = 1.00000 * scalar(x >= 0)
-        CFR1 = 0.05000 * scalar(
+        TTI2 = 1.00000 * pcr.scalar(x >= 0)
+        CFR1 = 0.05000 * pcr.scalar(
             x >= 0
         )  # refreezing efficiency constant in refreezing of freewater in snow
-        CFR2 = 0.05000 * scalar(x >= 0)
-        WHC1 = 0.10000 * scalar(x >= 0)
-        WHC2 = 0.10000 * scalar(x >= 0)
+        CFR2 = 0.05000 * pcr.scalar(x >= 0)
+        WHC1 = 0.10000 * pcr.scalar(x >= 0)
+        WHC2 = 0.10000 * pcr.scalar(x >= 0)
 
         # Partitioning into fractions rain and snow
         Temperature = T24  # Dimmie, let op: tijdelijke regel!!
-        RainFrac1 = max(0, min((Temperature - (TT1 - TTI1 / 2)) / TTI1, 1))
-        RainFrac2 = max(0, min((Temperature - (TT2 - TTI2 / 2)) / TTI2, 1))
+        RainFrac1 = pcr.max(0, pcr.min((Temperature - (TT1 - TTI1 / 2)) / TTI1, 1))
+        RainFrac2 = pcr.max(0, pcr.min((Temperature - (TT2 - TTI2 / 2)) / TTI2, 1))
         SnowFrac1 = 1 - RainFrac1  # fraction of precipitation which falls as snow
         SnowFrac2 = 1 - RainFrac2
 
@@ -784,18 +786,18 @@ class WflowModel(DynamicModel):
         SnowFall2 = SnowFrac2 * Precipitation2
         RainFall1 = RainFrac1 * Precipitation1  # rainfall depth
         RainFall2 = RainFrac2 * Precipitation2
-        PotSnowMelt1 = Cfmax1 * max(
+        PotSnowMelt1 = Cfmax1 * pcr.max(
             0, Temperature - TT1
         )  # Potential snow melt, based on temperature
-        PotSnowMelt2 = Cfmax2 * max(0, Temperature - TT2)
+        PotSnowMelt2 = Cfmax2 * pcr.max(0, Temperature - TT2)
         PotRefreezing1 = (
-            Cfmax1 * CFR1 * max(TT1 - Temperature, 0)
+            Cfmax1 * CFR1 * pcr.max(TT1 - Temperature, 0)
         )  # Potential refreezing, based on temperature
-        PotRefreezing2 = Cfmax2 * CFR2 * max(TT2 - Temperature, 0)
-        Refreezing1 = min(PotRefreezing1, self.FreeWater1)  # actual refreezing
-        Refreezing2 = min(PotRefreezing2, self.FreeWater2)
-        SnowMelt1 = min(PotSnowMelt1, self.DrySnow1)  # actual snow melt
-        SnowMelt2 = min(PotSnowMelt2, self.DrySnow2)
+        PotRefreezing2 = Cfmax2 * CFR2 * pcr.max(TT2 - Temperature, 0)
+        Refreezing1 = pcr.min(PotRefreezing1, self.FreeWater1)  # actual refreezing
+        Refreezing2 = pcr.min(PotRefreezing2, self.FreeWater2)
+        SnowMelt1 = pcr.min(PotSnowMelt1, self.DrySnow1)  # actual snow melt
+        SnowMelt2 = pcr.min(PotSnowMelt2, self.DrySnow2)
         self.DrySnow1 = (
             self.DrySnow1 + SnowFall1 + Refreezing1 - SnowMelt1
         )  # dry snow content
@@ -806,18 +808,18 @@ class WflowModel(DynamicModel):
         MaxFreeWater2 = self.DrySnow2 * WHC2
         self.FreeWater1 = self.FreeWater1 + SnowMelt1 + RainFall1
         self.FreeWater2 = self.FreeWater2 + SnowMelt2 + RainFall2
-        InSoil1 = max(
+        InSoil1 = pcr.max(
             self.FreeWater1 - MaxFreeWater1, 0
         )  # abundant water in snow pack which goes into soil
-        InSoil2 = max(self.FreeWater2 - MaxFreeWater2, 0)
+        InSoil2 = pcr.max(self.FreeWater2 - MaxFreeWater2, 0)
         self.FreeWater1 = self.FreeWater1 - InSoil1
         self.FreeWater2 = self.FreeWater2 - InSoil2
         # End of Snow Module
 
         # CALCULATION OF WATER BALANCES
         # surface water fluxes (2.2)
-        NetInSoil1 = max(0, (InSoil1 - self.InitLoss1))
-        NetInSoil2 = max(0, (InSoil2 - self.InitLoss2))
+        NetInSoil1 = pcr.max(0, (InSoil1 - self.InitLoss1))
+        NetInSoil2 = pcr.max(0, (InSoil2 - self.InitLoss2))
         Rhof1 = (1 - fsat1) * (NetInSoil1 / (NetInSoil1 + self.PrefR1)) * NetInSoil1
         Rhof2 = (1 - fsat2) * (NetInSoil2 / (NetInSoil2 + self.PrefR2)) * NetInSoil2
         Rsof1 = fsat1 * NetInSoil1
@@ -834,19 +836,19 @@ class WflowModel(DynamicModel):
         SzFC2 = self.S0FC2
         Sz1 = self.S01
         Sz2 = self.S02
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
         self.TMP = SzFC1
 
         # TODO: Check if this works
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         D01 = Dz1
         D02 = Dz2
         self.S01 = self.S01 - D01
@@ -858,16 +860,16 @@ class WflowModel(DynamicModel):
         SzFC2 = self.SsFC2
         Sz1 = self.Ss1
         Sz2 = self.Ss2
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         Ds1 = Dz1
         Ds2 = Dz2
         self.Ss1 = self.Ss1 - Ds1
@@ -879,25 +881,25 @@ class WflowModel(DynamicModel):
         SzFC2 = self.SdFC2
         Sz1 = self.Sd1
         Sz2 = self.Sd2
-        wz1 = max(1e-2, Sz1) / SzFC1
-        wz2 = max(1e-2, Sz2) / SzFC2
-        fD1 = scalar(wz1 > 1) * max(self.FdrainFC1, 1 - 1 / wz1) + scalar(
+        wz1 = pcr.max(1e-2, Sz1) / SzFC1
+        wz2 = pcr.max(1e-2, Sz2) / SzFC2
+        fD1 = pcr.scalar(wz1 > 1) * pcr.max(self.FdrainFC1, 1 - 1 / wz1) + pcr.scalar(
             wz1 <= 1
-        ) * self.FdrainFC1 * exp(self.beta1 * scalar(wz1 - 1))
-        fD2 = scalar(wz2 > 1) * max(self.FdrainFC2, 1 - 1 / wz2) + scalar(
+        ) * self.FdrainFC1 * pcr.exp(self.beta1 * pcr.scalar(wz1 - 1))
+        fD2 = pcr.scalar(wz2 > 1) * pcr.max(self.FdrainFC2, 1 - 1 / wz2) + pcr.scalar(
             wz2 <= 1
-        ) * self.FdrainFC2 * exp(self.beta2 * scalar(wz2 - 1))
-        Dz1 = max(0, min(fD1 * Sz1, Sz1 - 1e-2))
-        Dz2 = max(0, min(fD2 * Sz2, Sz2 - 1e-2))
+        ) * self.FdrainFC2 * pcr.exp(self.beta2 * pcr.scalar(wz2 - 1))
+        Dz1 = pcr.max(0, pcr.min(fD1 * Sz1, Sz1 - 1e-2))
+        Dz2 = pcr.max(0, pcr.min(fD2 * Sz2, Sz2 - 1e-2))
         Dd1 = Dz1
         Dd2 = Dz2
         self.Sd1 = self.Sd1 - Dd1
         self.Sd2 = self.Sd2 - Dd2
-        Y1 = min(
-            self.Fgw_conn1 * max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
+        Y1 = pcr.min(
+            self.Fgw_conn1 * pcr.max(0, self.wdlimU1 * self.SdFC1 - self.Sd1), Sghru1 - Eg1
         )
-        Y2 = min(
-            self.Fgw_conn2 * max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
+        Y2 = pcr.min(
+            self.Fgw_conn2 * pcr.max(0, self.wdlimU2 * self.SdFC2 - self.Sd2), Sghru2 - Eg2
         )
         # Y = Fgw_conn.*max(0,wdlimU.*SdFC-Sd); #nog matlab script
         self.Sd1 = self.Sd1 + Y1
@@ -907,43 +909,43 @@ class WflowModel(DynamicModel):
         # Groundwater store water balance (Sg) (2.5)
         NetGf = (self.Fhru1 * (Dd1 - Eg1 - Y1)) + (self.Fhru2 * (Dd2 - Eg2 - Y2))
         self.Sg = self.Sg + NetGf
-        Sgfree = max(self.Sg, 0)
-        Qg = min(Sgfree, (1 - exp(-self.K_gw)) * Sgfree)
+        Sgfree = pcr.max(self.Sg, 0)
+        Qg = pcr.min(Sgfree, (1 - pcr.exp(-self.K_gw)) * Sgfree)
         self.Sg = self.Sg - Qg
 
         # Surface water store water balance (Sr) (2.7)
         self.Sr = self.Sr + (self.Fhru1 * (QR1 - Er1)) + (self.Fhru2 * (QR2 - Er2)) + Qg
-        Qtot = min(self.Sr, (1 - exp(-self.K_rout)) * self.Sr)
+        Qtot = pcr.min(self.Sr, (1 - pcr.exp(-self.K_rout)) * self.Sr)
         self.Sr = self.Sr - Qtot
 
         # VEGETATION ADJUSTMENT (5)
 
         fveq1 = (
-            (1 / max((self.E01 / Utot1) - 1, 1e-3))
+            (1 / pcr.max((self.E01 / Utot1) - 1, 1e-3))
             * (keps / (1 + keps))
             * (ga1 / Gsmax1)
         )
         fveq2 = (
-            (1 / max((self.E02 / Utot2) - 1, 1e-3))
+            (1 / pcr.max((self.E02 / Utot2) - 1, 1e-3))
             * (keps / (1 + keps))
             * (ga2 / Gsmax2)
         )
-        fvmax1 = 1 - exp(-self.LAImax1 / self.LAIref1)
-        fvmax2 = 1 - exp(-self.LAImax2 / self.LAIref2)
-        fveq1 = min(fveq1, fvmax1)
-        fveq2 = min(fveq2, fvmax2)
-        dMleaf1 = -ln(1 - fveq1) * self.LAIref1 / self.SLA1 - self.Mleaf1
-        dMleaf2 = -ln(1 - fveq2) * self.LAIref2 / self.SLA2 - self.Mleaf2
+        fvmax1 = 1 - pcr.exp(-self.LAImax1 / self.LAIref1)
+        fvmax2 = 1 - pcr.exp(-self.LAImax2 / self.LAIref2)
+        fveq1 = pcr.min(fveq1, fvmax1)
+        fveq2 = pcr.min(fveq2, fvmax2)
+        dMleaf1 = -pcr.ln(1 - fveq1) * self.LAIref1 / self.SLA1 - self.Mleaf1
+        dMleaf2 = -pcr.ln(1 - fveq2) * self.LAIref2 / self.SLA2 - self.Mleaf2
 
         # Mleafnet1 = dMleaf1 * (dMleaf1/self.Tgrow1) + dMleaf1 * dMleaf1/self.Tsenc1
         # Mleafnet2 = dMleaf2 * (dMleaf1/self.Tgrow2) + dMleaf2 * dMleaf2/self.Tsenc2
         Mleafnet1 = (
-            scalar(dMleaf1 > 0) * (dMleaf1 / self.Tgrow1)
-            + scalar(dMleaf1 < 0) * dMleaf1 / self.Tsenc1
+            pcr.scalar(dMleaf1 > 0) * (dMleaf1 / self.Tgrow1)
+            + pcr.scalar(dMleaf1 < 0) * dMleaf1 / self.Tsenc1
         )
         Mleafnet2 = (
-            scalar(dMleaf2 > 0) * (dMleaf2 / self.Tgrow2)
-            + scalar(dMleaf2 < 0) * dMleaf2 / self.Tsenc2
+            pcr.scalar(dMleaf2 > 0) * (dMleaf2 / self.Tgrow2)
+            + pcr.scalar(dMleaf2 < 0) * dMleaf2 / self.Tsenc2
         )
 
         self.Mleaf1 = self.Mleaf1 + Mleafnet1
@@ -954,8 +956,8 @@ class WflowModel(DynamicModel):
         # Updating diagnostics
         self.LAI1 = self.SLA1 * self.Mleaf1  # (5.3)
         self.LAI2 = self.SLA2 * self.Mleaf2
-        fveg1 = 1 - exp(-self.LAI1 / self.LAIref1)  # (5.3)
-        fveg2 = 1 - exp(-self.LAI2 / self.LAIref2)
+        fveg1 = 1 - pcr.exp(-self.LAI1 / self.LAIref1)  # (5.3)
+        fveg2 = 1 - pcr.exp(-self.LAI2 / self.LAIref2)
         fsoil1 = 1 - fveg1
         fsoil2 = 1 - fveg2
         w01 = self.S01 / self.S0FC1  # (2.1)

--- a/wflow/wflow_wave.py
+++ b/wflow/wflow_wave.py
@@ -97,15 +97,9 @@ $Id: wflow_wave.py 913 2014-02-04 13:10:51Z schelle $
 $Rev: 913 $
 
 """
-import numpy
-import os
 import os.path
-import getopt
 
 from wflow.wf_DynamicFramework import *
-
-# import scipy
-
 from wflow.wflow_adapt import *
 
 

--- a/wflow/wflow_wave.py
+++ b/wflow/wflow_wave.py
@@ -170,7 +170,9 @@ class WflowModel(pcraster.framework.DynamicModel):
                 + (self.ChannelForm * self.WaterLevelDyn * 2.0)
                 + self.ChannelBottomWidth
             ) / 2.0
-            self.AChannel = pcr.min(self.WaterLevelDyn, self.ChannelDepth) * ChannelSurface
+            self.AChannel = (
+                pcr.min(self.WaterLevelDyn, self.ChannelDepth) * ChannelSurface
+            )
             self.AFloodplain = pcr.max(
                 (self.WaterLevelDyn - self.ChannelDepth) * self.FloodplainWidth, 0.0
             )
@@ -272,7 +274,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             self.FloodPlainVol = self.AFloodplain * self.ChannelLength
             self.ChannelVol = self.AChannel * self.ChannelLength
             fxboun = pcr.ifthen(self.dynHBoundary > 0, pcr.scalar(levelBoun))
-            self.WaterLevelDyn = pcr.cover(pcr.ifthen(fxboun > 0, fxboun), self.WaterLevelDyn)
+            self.WaterLevelDyn = pcr.cover(
+                pcr.ifthen(fxboun > 0, fxboun), self.WaterLevelDyn
+            )
 
     def stateVariables(self):
         """ 
@@ -405,7 +409,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         if wflow_dynriver == "not_set":
             self.DynRiver = pcr.boolean(self.River)
         else:
-            self.DynRiver = pcr.boolean(pcr.readmap(os.path.join(self.Dir, wflow_dynriver)))
+            self.DynRiver = pcr.boolean(
+                pcr.readmap(os.path.join(self.Dir, wflow_dynriver))
+            )
 
         self.ChannelDepth = pcrut.readmapSave(
             self.Dir + "/staticmaps/ChannelDepth.map", 8.0
@@ -423,7 +429,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         self.ChannelRoughness = pcrut.readmapSave(
             self.Dir + "/staticmaps/ChannelRoughness.map", 0.03
         )
-        self.ChannelRoughness = self.ChannelRoughness * pcr.scalar(pcr.boolean(self.DynRiver))
+        self.ChannelRoughness = self.ChannelRoughness * pcr.scalar(
+            pcr.boolean(self.DynRiver)
+        )
         # COnvert to chezy
         # self.ChannelRoughness = 1.49/self.ChannelRoughness
         self.ChannelLength = self.DCL * pcr.scalar(pcr.boolean(self.DynRiver))
@@ -441,7 +449,9 @@ class WflowModel(pcraster.framework.DynamicModel):
             * pcr.scalar(pcr.boolean(self.DynRiver)),
         )
 
-        self.Structures = pcr.boolean(self.ZeroMap * pcr.scalar(pcr.boolean(self.DynRiver)))
+        self.Structures = pcr.boolean(
+            self.ZeroMap * pcr.scalar(pcr.boolean(self.DynRiver))
+        )
         self.StructureA = self.ZeroMap * pcr.scalar(pcr.boolean(self.DynRiver))
         self.StructureB = self.ZeroMap * pcr.scalar(pcr.boolean(self.DynRiver))
         self.StructureCrestLevel = self.ZeroMap * pcr.scalar(pcr.boolean(self.DynRiver))
@@ -496,7 +506,9 @@ class WflowModel(pcraster.framework.DynamicModel):
         #: here which pick upt the variable save by a call to wf_suspend()
         if self.reinit == 1:
             self.logger.info("Setting initial conditions to default (zero!)")
-            self.WaterLevelDyn = (self.ZeroMap + 0.1) * pcr.scalar(pcr.boolean(self.River))
+            self.WaterLevelDyn = (self.ZeroMap + 0.1) * pcr.scalar(
+                pcr.boolean(self.River)
+            )
             self.SurfaceRunoffDyn = self.ZeroMap * pcr.scalar(pcr.boolean(self.River))
 
         else:

--- a/wflow/wrappers/rtc/wrapperExtended.py
+++ b/wflow/wrappers/rtc/wrapperExtended.py
@@ -1,4 +1,3 @@
-import bmi
 import bmi.wrapper
 
 


### PR DESCRIPTION
This removes the `from numpy import *` and `from pcraster import *`, which was a pain, since there were many clashes and it was not always clear which library was being used. This should help making refactoring easier in the future.

There are still a few wildcard imports, but they are internal.

From now on let's only use `import numpy as np` and `import pcraster as pcr`, and try to comply with:

https://www.python.org/dev/peps/pep-0008/#imports
http://google.github.io/styleguide/pyguide.html#22-imports

Because not in all cases it was immediately clear what was being used, it may be that some errors were made. These errors will throw and not silently change behavior (e.g. numpy methods won't accept pcraster objects etc.), so can be easily fixed as we encounter them.