### PR TITLE
Fixed Docker build and numba.core.errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
 # DockerFile for PCR-GLOB model. The ini-file should be mounted as config.ini,
 # the input data root directory should be mounted as /data
-FROM ewatercycle/pcraster-container:421
-MAINTAINER Willem van Verseveld <Willem.vanVerseveld@deltares.nl>
-
-RUN apt-get update -y
-
-# INSTALL compilers and build toold
-RUN apt-get install -y python3-setuptools python3-pip python3-gdal
-
-# INSTALL pip packages
-RUN pip3 install numba
+FROM continuumio/anaconda3
+LABEL maintainer="Willem van Verseveld <Willem.vanVerseveld@deltares.nl>"
 
 # build
 COPY . /opt/wflow/
 WORKDIR /opt/wflow
-RUN python3 setup.py install
+RUN conda env create -f environment.yml
+RUN conda run -n wflow python setup.py install
 VOLUME /data
-ENV PYTHONPATH /opt/pcraster-4.2.1/build/bin
 WORKDIR /
-ENTRYPOINT ["python3","/usr/local/bin/wflow_sbm.py","-C","/data"]
+ENTRYPOINT ["conda", "run", "-n", "wflow", "python3", "-m", "wflow.wflow_sbm"]

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - netcdf4>=1.4.1
   - xarray>=0.11
   - cftime>=1.0.4
-  - numba<=0.48
+  - numba>=0.49
   - pyproj>=2.4
   - python-dateutil>=2.7
   # optional

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - netcdf4>=1.4.1
   - xarray>=0.11
   - cftime>=1.0.4
-  - numba>=0.48
+  - numba<=0.48
   - pyproj>=2.4
   - python-dateutil>=2.7
   # optional
@@ -28,4 +28,4 @@ dependencies:
   - sphinx_rtd_theme
   - matplotlib
   - pip:
-    - bmi-python
+      - bmi-python

--- a/wflow/wflow_funcs.py
+++ b/wflow/wflow_funcs.py
@@ -29,7 +29,11 @@ from numba import jit
 import math
 import numpy as np
 import pcraster as pcr
-from numba.errors import NumbaPendingDeprecationWarning
+try:
+    from numba.core.errors import NumbaPendingDeprecationWarning
+except ImportError:
+    from numba.errors import NumbaPendingDeprecationWarning
+
 import warnings
 
 warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)

--- a/wflow/wflow_sbm.py
+++ b/wflow/wflow_sbm.py
@@ -80,7 +80,11 @@ import pdb
 import math
 from numba import jit
 
-from numba.errors import NumbaPendingDeprecationWarning
+try:
+    from numba.core.errors import NumbaPendingDeprecationWarning
+except ImportError:
+    from numba.errors import NumbaPendingDeprecationWarning
+
 import warnings
 
 warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)


### PR DESCRIPTION
Based on the latest install instructions, just with conda, as the pcraster container just makes things harder.

Note that I had to pin numba, as the wflow is not yet compatible with releases later than 0.48.

This should fix the failing builds over at https://hub.docker.com/repository/docker/deltares/wflow.