### PR TITLE
caught exception in estimate_iterations_kin_wave when all map values …

### DIFF
--- a/wflow/wflow_funcs.py
+++ b/wflow/wflow_funcs.py
@@ -99,10 +99,12 @@ def set_dd(ldd, _ldd_us=_ldd_us, pit_value=_pits):
 ###############################################################################
 
 def estimate_iterations_kin_wave(Q, Beta, alpha, timestepsecs, dx, mv):
-    
-    celerity = pcr.ifthen(Q > 0.0, 1.0 / (alpha * Beta * Q**(Beta-1)))
-    courant = (timestepsecs / dx) * celerity
-    np_courant = pcr.pcr2numpy(courant, mv)
+    if (pcr.pcr2numpy(Q, mv)).max() > 0:
+        celerity = pcr.ifthen(Q > 0.0, 1.0 / (alpha * Beta * Q**(Beta-1)))
+        courant = (timestepsecs / dx) * celerity
+        np_courant = pcr.pcr2numpy(courant, mv)
+    else:
+        np_courant = np.zeros(pcr.pcr2numpy(Q, mv).shape) + mv
     np_courant[np_courant==mv] = np.nan
     try:
         it_kin = int(np.ceil(1.25*(np.nanpercentile(np_courant,95))))


### PR DESCRIPTION
I have fixed a problem occurring when running in BMI. The functions ```estimate_iterations_kin_wave``` was called such that its first argument was a pcr-map containing only zeros. That caused an exception as zero**(-x) is not possible. When at least one value is above zero in the first argument, the error does not occur (tested). I test for this condition before deciding what to do to compute the celerity. This pull request refers to #37 