### PR TITLE
fix glacier melt issue

### DIFF
--- a/wflow/wflow_sbm.py
+++ b/wflow/wflow_sbm.py
@@ -2352,7 +2352,7 @@ class WflowModel(pcraster.framework.DynamicModel):
                 # Convert to mm per grid cell and add to snowmelt
                 self.GlacierMelt = self.GlacierMelt * self.GlacierFrac
                 self.RainFallPlusMelt = (
-                    self.RainFallPlusMelt + self.GlacierMelt
+                    self.RainFallPlusMelt + pcr.cover(self.GlacierMelt,0.0)
                 )
         else:
             self.RainFallPlusMelt = self.EffectivePrecipitation


### PR DESCRIPTION
glacier melt can contain missing values, because input parameters can have missing values.
this works through in the infiltration (rainfall + melt). to avoid missing values pcr.cover(self.GlacierMelt,0.0) is now used.